### PR TITLE
Fix/handle errors on missing shoreline class and layers, improve doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,95 +20,96 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `Forecasting Tab`: Fix issue on forecasting generating weird uncertainty points when date value of month is not 01.
-- Fix proper end time logging of shoreline change and forecasting.
+- `Forecasting Tab`: Fixed issue on forecasting generating weird uncertainty points when date value of month was not 01.
+- Fixed proper end time logging of shoreline change and forecasting.
 - Minor bug fixes.
 
 ### Added
 
-- `Visualization Tab`: Add option to select column, and input uncertainty value to support layers generated outside QSCAT.
-- `Baseline Tab`, `Automator Tab`: Add smoothing distance field.
-- `Shoreline Change Tab`, `Area Change Tab`, `Forecasting Tab`, `Visualization Tab`, `Summary Reports Tab`: Add input saving.
-- `Help Tab`: Add useful links.
-- `Shorelines Tab`: Add selected shorelines layer validation when changing layer selections.
+- `Visualization Tab`: Added option to select column, and input uncertainty value to support layers generated outside QSCAT.
+- `Baseline Tab`, `Automator Tab`: Added smoothing distance field.
+- `Shoreline Change Tab`, `Area Change Tab`, `Forecasting Tab`, `Visualization Tab`, `Summary Reports Tab`: Added input saving.
+- `Help Tab`: Added useful links.
+- `Shorelines Tab`: Added selected shorelines layer validation when changing layer selections.
 
 ### Changed
 
-- `Shoreline Change Tab`: Make newest and oldest date selection automatic; no need to button to update.
-- Major code reformatting and refactor.
-- `User Manual`: Update figures and texts.
+- `Shoreline Change Tab`: Made newest and oldest date selection automatic; no need for a button to update.
+- Major code reformatting and refactoring.
+- `User Manual`: Updated figures and texts.
 
 ## [0.4.0] - 2024-05-06
 
 ### Fixed
 
-- `Visualization Tab`: Add missing stable class for SCE.
-- `Visualization Tab`: Fix Quantile and Jenks negative classification that includes stable values.
+- `Visualization Tab`: Added missing stable class for SCE.
+- `Visualization Tab`: Fixed Quantile and Jenks negative classification that included stable values.
 
 ### Added
 
-- `Area Change Tab`: Add attributes for oldest shoreline length, average shoreline length, and mean shoreline displacement in area change vector layer output.
-- `Area Change Tab`: Add oldest shoreline length and mean shoreline displacement in summary reports.
-- Add QSCAT access to the plugin menu.
-- Add transect cast, shoreline change, and forecasting execution time in QGIS message log.
+- `Area Change Tab`: Added attributes for oldest shoreline length, average shoreline length, and mean shoreline displacement in area change vector layer output.
+- `Area Change Tab`: Added oldest shoreline length and mean shoreline displacement in summary reports.
+- Added QSCAT access to the plugin menu.
+- Added transect cast, shoreline change, and forecasting execution time in QGIS message log.
 
 ### Changed
 
-- Refactor and style some codes using pylint, ruff, and black.
-- UI: Update labels for consistency.
-- Docs: Improve some sections.
+- Refactored and styled some codes using pylint, ruff, and black.
+- UI: Updated labels for consistency.
+- Docs: Improved some sections.
 
 ### Breaking Changes
 
-- `Visualization Tab`: Improved UI and reading of input. This change requires all previous stat layers to be regenerated.
+- `Visualization Tab`: Improved UI and reading of input. This change required all previous stat layers to be regenerated.
 
 ## [0.3.1] - 2024-04-21
 
 ### Fixed
 
-- Fix `Area Change Tab` visualization error.
-- Fix `Forecasting Tab` error.
+- Fixed `Area Change Tab` visualization error.
+- Fixed `Forecasting Tab` error.
 
 ## [0.3.0] - 2024-04-20
 
 ### Added
 
-- Add checkbox to hide `Baseline orientation`.
-- Add `Forecasting Tab` summary report.
+- Added checkbox to hide `Baseline orientation`.
+- Added `Forecasting Tab` summary report.
 
 ### Changed
 
-- Improve GUI icons design and made as SVGs for better quality.
+- Improved GUI icons design and made as SVGs for better quality.
 
 ### Fixed
 
-- Fix `Forecasting Tab` transect layer input to display line string layer only, and show CRS.
+- Fixed `Forecasting Tab` transect layer input to display line string layer only, and show CRS.
 
 ## [0.2.0] - 2024-04-14
 
 ### Added
 
-- Add `Summary Reports Tab` and enabling of individual reports for a dedicated summary reports setting.
+- Added `Summary Reports Tab` and enabling of individual reports for a dedicated summary reports setting.
 
 ### Changed
 
-- Modify `Area Change Tab` to read newest and oldest date without requiring to `Update` from `Shoreline Change Tab`.
-- Modify `Forecasting Tab` to input a transect layer.
-- Move default summary reports location to user's home directory to prevent summary reports from getting deleted when the plugin is updated.
-- Change file naming and foldering of summary reports to ``<computation>/qscat_<version>_<computation>_<datetime>.txt``
-- Refactor and improve the majority of the codes. 
-- Improve some parts of user manual (discussions and figures).
+- Modified `Area Change Tab` to read newest and oldest date without requiring to `Update` from `Shoreline Change Tab`.
+- Modified `Forecasting Tab` to input a transect layer.
+- Moved default summary reports location to user's home directory to prevent summary reports from getting deleted when the plugin is updated.
+- Changed file naming and foldering of summary reports to ``<computation>/qscat_<version>_<computation>_<datetime>.txt``
+- Refactored and improved the majority of the code.
+- Improved some parts of the user manual (discussions and figures).
 
 ### Removed
 
-- Remove version number in dock widget title for cleaner screenshots.
+- Removed version number in dock widget title for cleaner screenshots.
 
 ### Fixed
 
-- Fix and refactor `update_newest_oldest_date()` function in `Shoreline Change Tab` > `Pairwise Comparison of Shorelines` now properly showing what is `newest` and `oldest` date.
-- Fix `Transect Count` group box in `Transect Tab` not being enabled and disabled.
-- Fix summary reports for `Shoreline Change Tab` not being generated.
+- Fixed and refactored `update_newest_oldest_date()` function in `Shoreline Change Tab` > `Pairwise Comparison of Shorelines` now properly showing what is `newest` and `oldest` date.
+- Fixed `Transect Count` group box in `Transect Tab` not being enabled and disabled.
+- Fixed summary reports for `Shoreline Change Tab` not being generated.
 
 ## [0.1.0] - 2024-04-07
+
 
 _First release_.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.2] - Unreleased
+## [0.4.2] - 2025-11-02
 
-### TODO
+### Fixed
 
-- `Forecasting Tab`: Offers forecasting options from transects layer or from LRR layer.
-- `Forecasting Tab`: Improve forecasting input; currently it depends on shoreline change inputs such newest and oldest date, and transect-shoreline intersections.
+- `Shoreline Change Tab`: Fixed `ZeroDivisionError` in calculation when preparing summary reports with no available data (classes and layers).
 
+### Added
 
-## [0.4.1] - 2024-07-18
+- Added `environment-3.36.1.yml` file for local development setup.
+- Added local development setup instructions in `README.md`.
+
+## [0.4.2] - 2024-07-18
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `environment-3.36.1.yml` file for local development setup.
 - Added local development setup instructions in `README.md`.
 
-## [0.4.2] - 2024-07-18
+## [0.4.1] - 2024-07-18
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `environment-3.36.1.yml` file for local development setup.
 - Added local development setup instructions in `README.md`.
 
+### Changed
+
+- Improved documentation.
+
 ## [0.4.1] - 2024-07-18
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -29,7 +29,7 @@ authors:
 - family-names: "Siringan"
   given-names: "Fernando"
 
-version: 0.4.1
+version: 0.4.2
 date-released: "2024-07-18"
 url: "https://github.com/qscat/qscat"
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,51 @@ See [QSCAT User Manual - Sample Workflow](https://qscat.github.io/docs/latest/ma
 
 - We welcome contributions to QSCAT! Given that the plugin is in its initial stage, **bug reports are our top priority** as they help us identify and address issues to improve the stability and functionality of QSCAT. Whether it's code improvements, bug fixes, documentation enhancements, or translations, every contribution helps make QSCAT better for everyone. Please see our [Contribution Guide](CONTRIBUTING.md) for more details on how to get involved.
 
+
+## Development
+
+### Environment Setup
+
+QSCAT development requires QGIS and its dependencies. Use conda to create isolated environments for different QGIS versions:
+
+1. Install Miniconda or Anaconda.
+2. Create the environment (replace `3.36.1` with your desired QGIS version):
+   ```bash
+   conda env create -f environment-3.36.1.yml
+   ```
+   If the environment already exists, update it:
+   ```bash
+   conda env update -f environment-3.36.1.yml
+   ```
+3. Activate it:
+   ```bash
+   conda activate qgis-3.36.1
+   ```
+
+Environment files are provided for specific QGIS versions (e.g., `environment-3.36.1.yml`). Check the `.github/workflows/` for CI-tested versions.
+
+### Running Tests
+
+Run the test suite with pytest:
+
+```bash
+pytest tests/ -v
+```
+
+For coverage reports:
+
+```bash
+pytest --cov=qscat/ --cov-report html tests/
+```
+
+Tests require the QGIS environment to be active. See CI workflows for automated testing.
+
+### Contributing
+
+- Follow the [Contribution Guide](CONTRIBUTING.md).
+- Ensure tests pass before submitting PRs.
+- Use GitHub Issues for bug reports and feature requests.
+
 ## License
 - **[GPL License 3.0](LICENSE):** The QSCAT plugin is licensed under GPL 3.0, per [QGIS'](https://blog.qgis.org/2016/05/29/licensing-requirements-for-qgis-plugins/) Open Source Software principles. This decision aligns with the requirement for plugins to comply with GPL version 2 or greater for distribution through the QGIS plugin system.
 

--- a/README.md
+++ b/README.md
@@ -140,9 +140,7 @@ Tests require the QGIS environment to be active. See CI workflows for automated 
 
 ### Contributing
 
-- Follow the [Contribution Guide](CONTRIBUTING.md).
-- Ensure tests pass before submitting PRs.
-- Use GitHub Issues for bug reports and feature requests.
+See the main Contributing section above.
 
 ## License
 - **[GPL License 3.0](LICENSE):** The QSCAT plugin is licensed under GPL 3.0, per [QGIS'](https://blog.qgis.org/2016/05/29/licensing-requirements-for-qgis-plugins/) Open Source Software principles. This decision aligns with the requirement for plugins to comply with GPL version 2 or greater for distribution through the QGIS plugin system.

--- a/README.md
+++ b/README.md
@@ -138,10 +138,6 @@ pytest --cov=qscat/ --cov-report html tests/
 
 Tests require the QGIS environment to be active. See CI workflows for automated testing.
 
-### Contributing
-
-See the main Contributing section above.
-
 ## License
 - **[GPL License 3.0](LICENSE):** The QSCAT plugin is licensed under GPL 3.0, per [QGIS'](https://blog.qgis.org/2016/05/29/licensing-requirements-for-qgis-plugins/) Open Source Software principles. This decision aligns with the requirement for plugins to comply with GPL version 2 or greater for distribution through the QGIS plugin system.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 
 [![QGIS](https://img.shields.io/badge/qgis-3.22.16_|_3.34.5_|_3.36.1-green)](https://download.qgis.org/downloads/)
-[![QGIS.org - 0.4.1](https://img.shields.io/badge/qgis.org-0.4.1-green.svg)](https://plugins.qgis.org/plugins/qscat)
+[![QGIS.org - 0.4.2](https://img.shields.io/badge/qgis.org-0.4.2-green.svg)](https://plugins.qgis.org/plugins/qscat)
 [![DOI](https://zenodo.org/badge/780723777.svg)](https://zenodo.org/doi/10.5281/zenodo.10938766)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/qscat/qscat/badge)](https://securityscorecards.dev/viewer/?uri=github.com/qscat/qscat)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8758/badge)](https://www.bestpractices.dev/projects/8758)

--- a/README.md
+++ b/README.md
@@ -92,13 +92,10 @@ See [QSCAT User Manual - Sample Workflow](https://qscat.github.io/docs/latest/ma
 - [QSCAT Documentation](https://qscat.github.io/docs/latest)
 - [QSCAT User Manual](https://qscat.github.io/docs/latest/manual)
 - [QSCAT Facebook Page](https://web.facebook.com/qscatplugin)
-- [QSCAT Facebook Group](https://web.facebook.com/groups/qscat)
-- [QSCAT Twitter](https://twitter.com/qscatplugin)
   
 ## Contributing
 
 - We welcome contributions to QSCAT! Given that the plugin is in its initial stage, **bug reports are our top priority** as they help us identify and address issues to improve the stability and functionality of QSCAT. Whether it's code improvements, bug fixes, documentation enhancements, or translations, every contribution helps make QSCAT better for everyone. Please see our [Contribution Guide](CONTRIBUTING.md) for more details on how to get involved.
-
 
 ## Development
 

--- a/docs/source/changelog/0.2.0-changelog.rst
+++ b/docs/source/changelog/0.2.0-changelog.rst
@@ -5,26 +5,26 @@ QSCAT 0.2.0 Changelog - 2024-04-14
 Added
 =====
 
-- Add `Summary Reports Tab` and enabling of individual reports for a dedicated summary reports setting.
+- Added `Summary Reports Tab` and enabling of individual reports for a dedicated summary reports setting.
 
 Changed
 =======
 
-- Modify `Area Change Tab` to read newest and oldest date without requiring to `Update` from `Shoreline Change Tab`.
-- Modify `Forecasting Tab` to input a transect layer.
-- Move default summary reports location to user's home directory to prevent summary reports from getting deleted when the plugin is updated.
-- Change file naming and foldering of summary reports to ``<computation>/qscat_<version>_<computation>_<datetime>.txt``
-- Refactor and improve the majority of the codes. 
-- Improve some parts of user manual (discussions and figures).
+- Modified `Area Change Tab` to read newest and oldest date without requiring to `Update` from `Shoreline Change Tab`.
+- Modified `Forecasting Tab` to input a transect layer.
+- Moved default summary reports location to user's home directory to prevent summary reports from getting deleted when the plugin is updated.
+- Changed file naming and foldering of summary reports to ``<computation>/qscat_<version>_<computation>_<datetime>.txt``
+- Refactored and improved the majority of the codes. 
+- Improved some parts of user manual (discussions and figures).
 
 Removed
 =======
 
-- Remove version number in dock widget title for cleaner screenshots.
+- Removed version number in dock widget title for cleaner screenshots.
 
 Fixed
 =====
 
-- Fix and refactor `update_newest_oldest_date()` function in `Shoreline Change Tab` > `Pairwise Comparison of Shorelines` now properly showing what is `newest` and `oldest` date.
-- Fix `Transect Count` group box in `Transect Tab` not being enabled and disabled.
-- Fix summary reports for `Shoreline Change Tab` not being generated.
+- Fixed and refactored `update_newest_oldest_date()` function in `Shoreline Change Tab` > `Pairwise Comparison of Shorelines` now properly showing what is `newest` and `oldest` date.
+- Fixed `Transect Count` group box in `Transect Tab` not being enabled and disabled.
+- Fixed summary reports for `Shoreline Change Tab` not being generated.

--- a/docs/source/changelog/0.3.0-changelog.rst
+++ b/docs/source/changelog/0.3.0-changelog.rst
@@ -5,15 +5,15 @@ QSCAT 0.3.0 Changelog - 2024-04-20
 Added
 =====
 
-- Add checkbox to hide `Baseline orientation`.
-- Add `Forecasting Tab` summary report.
+- Added checkbox to hide `Baseline orientation`.
+- Added `Forecasting Tab` summary report.
 
 Changed
 =======
 
-- Improve GUI icons design and made as SVGs for better quality.
+- Improved GUI icons design and made as SVGs for better quality.
 
 Fixed
 =====
 
-- Fix `Forecasting Tab` transect layer input to display line string layer only, and show CRS.
+- Fixed `Forecasting Tab` transect layer input to display line string layer only, and show CRS.

--- a/docs/source/changelog/0.3.1-changelog.rst
+++ b/docs/source/changelog/0.3.1-changelog.rst
@@ -5,5 +5,5 @@ QSCAT 0.3.1 Changelog - 2024-04-21
 Fixed
 =====
 
-- Fix `Area Change Tab` visualization error.
-- Fix `Forecasting Tab` error.
+- Fixed `Area Change Tab` visualization error.
+- Fixed `Forecasting Tab` error.

--- a/docs/source/changelog/0.4.0-changelog.rst
+++ b/docs/source/changelog/0.4.0-changelog.rst
@@ -2,11 +2,13 @@
 QSCAT 0.4.0 Changelog - 2024-05-06
 ==================================
 
+
 Fixed
 =====
 
 - `Visualization Tab`: Add missing stable class for SCE.
 - `Visualization Tab`: Fix Quantile and Jenks negative classification that includes stable values.
+
 
 Added
 =====
@@ -16,12 +18,14 @@ Added
 - Add QSCAT access to the plugin menu.
 - Add transect cast, shoreline change, and forecasting execution time in QGIS message log.
 
+
 Changed
 =======
 
 - Refactor and style some codes using pylint, ruff, and black.
 - UI: Update labels for consistency.
 - Docs: Improve some sections.
+
 
 Breaking Changes
 ================

--- a/docs/source/changelog/0.4.1-changelog.rst
+++ b/docs/source/changelog/0.4.1-changelog.rst
@@ -2,12 +2,14 @@
 QSCAT 0.4.1 Changelog - 2024-07-18
 ==================================
 
+
 Fixed
 =====
 
 - `Forecasting Tab`: Fix issue on forecasting generating weird uncertainty points when date value of month is not 01.
 - Fix proper end time logging of shoreline change and forecasting.
 - Minor bug fixes.
+
 
 Added
 =====
@@ -17,6 +19,7 @@ Added
 - `Shoreline Change Tab`, `Area Change Tab`, `Forecasting Tab`, `Visualization Tab`, `Summary Reports Tab`: Add input saving.
 - `Help Tab`: Add useful links.
 - `Shorelines Tab`: Add selected shorelines layer validation when changing layer selections.
+
 
 Changed
 =======

--- a/docs/source/changelog/0.4.2-changelog.rst
+++ b/docs/source/changelog/0.4.2-changelog.rst
@@ -2,10 +2,12 @@
 QSCAT 0.4.2 Changelog - 2025-11-02
 ==================================
 
+
 Fixed
 =====
 
-- `Shoreline Change Tab`: Fixed `ZeroDivisionError` in shoreline change stats calculation when preparing summary reports with no available data.
+- `Shoreline Change Tab`: Fixed `ZeroDivisionError` in calculation when preparing summary reports with no available data (classes and layers).
+
 
 Added
 =====

--- a/docs/source/changelog/0.4.2-changelog.rst
+++ b/docs/source/changelog/0.4.2-changelog.rst
@@ -1,0 +1,14 @@
+==================================
+QSCAT 0.4.2 Changelog - 2025-11-02
+==================================
+
+Fixed
+=====
+
+- `Shoreline Change Tab`: Fixed `ZeroDivisionError` in shoreline change stats calculation when preparing summary reports with no available data.
+
+Added
+=====
+
+- Added `environment-3.36.1.yml` file for local development setup.
+- Added local development setup instructions in `README.md`.

--- a/docs/source/changelog/0.4.2-changelog.rst
+++ b/docs/source/changelog/0.4.2-changelog.rst
@@ -9,8 +9,15 @@ Fixed
 - `Shoreline Change Tab`: Fixed `ZeroDivisionError` in calculation when preparing summary reports with no available data (classes and layers).
 
 
+
 Added
 =====
 
 - Added `environment-3.36.1.yml` file for local development setup.
 - Added local development setup instructions in `README.md`.
+
+
+Changed
+=======
+
+- Improved documentation.

--- a/docs/source/changelog/index.rst
+++ b/docs/source/changelog/index.rst
@@ -6,7 +6,8 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 
 .. toctree::
    :maxdepth: 1
-   
+
+   0.4.2 <0.4.2-changelog>
    0.4.1 <0.4.1-changelog>
    0.4.0 <0.4.0-changelog>
    0.3.1 <0.3.1-changelog>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,8 +43,8 @@ latex_elements['preamble'] = r"""
 """
 latex_elements['pointsize'] = '11pt'
 
-release = "0.4.1"
-version = "0.4.1"
+release = "0.4.2"
+version = "0.4.2"
 
 # -- General configuration
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -112,11 +112,6 @@ html_theme_options = {
             "url": "https://facebook.com/qscatplugin",
             "icon": "fa-brands fa-square-facebook",
         },
-        {
-            "name": "Twitter",
-            "url": "https://twitter.com/qscatplugin",
-            "icon": "fa-brands fa-square-twitter",
-        },
     ],
     "secondary_sidebar_items": ["page-toc", "edit-this-page", "sourcelink"],
     "footer_start": ["copyright", "sphinx-version"],

--- a/docs/source/manual/introduction/features.rst
+++ b/docs/source/manual/introduction/features.rst
@@ -10,14 +10,15 @@ Features
       :local:
 
 - **Shoreline Change:** Computes shoreline change statistics: shoreline change envelope (SCE), net shoreline movement (NSM), end-point rate (EPR), linear regression rate (LRR), and weighted linear regression rate (WLR) (see :ref:`tab_shoreline_change`).
-  
-- **Area Change:** Changingalculates length and area of accreting, stable, and eroding coastal segments (see :ref:`tab_area_change`).
 
-- **Forecasting:** Predict future shoreline positions including uncertainty areas (see :ref:`tab_forecasting`).
+- **Area Change:** Calculates the length and area of accreting, stable, and eroding coastal segments (see :ref:`tab_area_change`).
 
-- **Automator:** Offer tools that automate manual repetitive tasks (see :ref:`tab_automator`).
-  
-- **Visualization:** Shoreline and area change, forecasting results are visualized in the map for easy interpretation (see :ref:`tab_visualization`).
+- **Forecasting:** Predicts future shoreline positions, including uncertainty areas (see :ref:`tab_forecasting`).
 
-- **Summary Reports:** Generates a comprehensive summary reports of the analysis results (see :ref:`tab_summary_reports`).
+- **Automator:** Offers tools that automate manual repetitive tasks (see :ref:`tab_automator`).
+
+- **Visualization:** Visualizes shoreline change, area change, and forecasting results in the map for easy interpretation (see :ref:`tab_visualization`).
+
+- **Summary Reports:** Generates a comprehensive summary report of the analysis results (see :ref:`tab_summary_reports`).
+
 

--- a/docs/source/manual/introduction/installation.rst
+++ b/docs/source/manual/introduction/installation.rst
@@ -4,7 +4,8 @@
 Installation
 ************
 
-The QSCAT plugin can be installed in two ways: by using the QGIS plugin repository (recommended) or by installing from a ZIP file. The steps to install the plugin are similar regardless of the operating system (Windows, Linux, and Mac OS). The following sections provide detailed instructions on how to install the plugin using both methods.
+
+The QSCAT plugin can be installed in two ways: by using the QGIS plugin repository (recommended) or by installing from a ZIP file. The steps to install the plugin are similar regardless of the operating system (Windows, Linux, or Mac OS). The following sections provide detailed instructions on how to install the plugin using both methods.
 
 .. only:: html
 
@@ -14,7 +15,7 @@ The QSCAT plugin can be installed in two ways: by using the QGIS plugin reposito
 
 .. note::
 
-   Keep in mind that the latest version of QSCAT plugin may not always be immediately available in the official QGIS plugin repository. New versions always require approval from the QGIS team. To stay up-to-date, consider checking the plugin's GitHub repository directly (https://github.com/qscat/qscat/releases/latest), where you can find the most recent releases and changelogs.
+   Keep in mind that the latest version of the QSCAT plugin may not always be immediately available in the official QGIS plugin repository. New versions always require approval from the QGIS team. To stay up-to-date, consider checking the plugin's GitHub repository directly (https://github.com/qscat/qscat/releases/latest), where you can find the most recent releases and changelogs.
 
 By QGIS Plugin Repository
 =========================
@@ -23,7 +24,7 @@ By QGIS Plugin Repository
 2. Check :guilabel:`Show also experimental plugins`. Go to :guilabel:`All`.
 3. Search (or type) ``QGIS Shoreline Change Analysis Tool``.
 4. Click :guilabel:`Install Plugin`.
-5. Go to :guilabel:`Installed`. The ``QGIS Shoreline Change Analysis Tool`` should now appear in the list if the plugin is installed succesfuly. Check the checkbox to enable the plugin (if not checked).
+5. Go to :guilabel:`Installed`. The ``QGIS Shoreline Change Analysis Tool`` should now appear in the list if the plugin is installed successfully. Check the checkbox to enable the plugin (if not checked).
 6. Once enabled, the |qscat| icon will appear in the toolbar.
 
 By Install from ZIP
@@ -32,7 +33,7 @@ By Install from ZIP
 1. Download the latest ``qscat.zip`` file from the following link: https://github.com/qscat/qscat/releases/latest. Or ``qscat-x.y-z.zip`` from https://plugins.qgis.org/plugins/qscat/.
 2. Open ``QGIS``, :menuselection:`Plugins --> Manage and Install Plugins... --> Install from ZIP`.
 3. Click :guilabel:`...`, find the downloaded ``qscat.zip`` (or ``qscat-x.y-z.zip``) then click :guilabel:`Install Plugin`. Finally, proceed with the warning if asked.
-4. Go to :guilabel:`Installed`. The ``QGIS Shoreline Change Analysis Tool`` should now appear in the list if the plugin is installed succesfuly. Check the checkbox to enable the plugin (if not checked).
+4. Go to :guilabel:`Installed`. The ``QGIS Shoreline Change Analysis Tool`` should now appear in the list if the plugin is installed successfully. Check the checkbox to enable the plugin (if not checked).
 5. Once enabled, the |qscat| icon will appear in the toolbar.
 
 .. |qscat| image:: /img/qscat.png

--- a/docs/source/manual/introduction/overview.rst
+++ b/docs/source/manual/introduction/overview.rst
@@ -4,6 +4,7 @@
 Overview
 ********
 
+
 QGIS Shoreline Change Analysis Tool (QSCAT) is a plugin developed for the Quantum GIS (QGIS) freeware. It is patterned after the Digital Shoreline Analysis System (DSAS), an ArcGIS add-in. Being QGIS-based, QSCAT is more readily accessible than DSAS. Like DSAS, QSCAT computes the rate and magnitude of shoreline changes for different periods. It can generate commonly used shoreline change statistics such as Net Shoreline Movement (NSM), End-Point Rate (EPR), and Linear Regression Rate (LRR) from a time series of shoreline vectors.
 
-Although the output statistics of this plugin are more limited than what DSAS is capable of, QSCAT has some additional features. In NSM and EPR, a feature can compare any two shoreline vectors by selecting a date for comparison. More importantly, it can estimate the length and areal extent of the eroding, stable, and accreting coastal segments. Such information is essential for coastal erosion studies.
+Although the output statistics of this plugin are more limited than those of DSAS, QSCAT has some additional features. In NSM and EPR, a feature allows you to compare any two shoreline vectors by selecting a date for comparison. More importantly, it can estimate the length and areal extent of the eroding, stable, and accreting coastal segments. Such information is essential for coastal erosion studies.

--- a/docs/source/manual/introduction/requirements.rst
+++ b/docs/source/manual/introduction/requirements.rst
@@ -4,9 +4,10 @@
 Requirements
 ************
 
-To use QSCAT, you need QGIS, which is a free and open-source Geographic Information System (GIS) software. You can download different versions of QGIS from the `QGIS website <https://qgis.org/en/site/forusers/download.html>`_ (see for the versions below). Ensure that your system meets the system requirements of QGIS: a standard PC with at least 4GB of RAM running on Windows, Linux or Mac OS X.
 
-Since QSCAT is just a plugin of QGIS (not standalone software), if you meet the system requirements of QGIS, QSCAT should run fine on your system.
+To use QSCAT, you need QGIS, which is a free and open-source Geographic Information System (GIS) software. You can download different versions of QGIS from the `QGIS website <https://qgis.org/en/site/forusers/download.html>`_ (see the versions below). Ensure that your system meets the requirements for QGIS: a standard PC with at least 4GB of RAM running on Windows, Linux, or Mac OS X.
+
+Since QSCAT is a plugin for QGIS (not standalone software), if you meet the system requirements of QGIS, QSCAT should run fine on your system.
 
 QGIS versions
 -------------

--- a/docs/source/manual/others/appendices/index.rst
+++ b/docs/source/manual/others/appendices/index.rst
@@ -1,5 +1,6 @@
 .. _others_appendices:
 
+
 **********
 Appendices
 **********

--- a/docs/source/manual/others/contributors.rst
+++ b/docs/source/manual/others/contributors.rst
@@ -5,6 +5,7 @@ Contributors
 Authors
 =======
 
+
 The initial version of QSCAT was developed by the UP-DMMMSU CoastER team:
 
 .. csv-table::

--- a/docs/source/manual/others/help_and_support.rst
+++ b/docs/source/manual/others/help_and_support.rst
@@ -2,9 +2,10 @@
 Help and Support
 ****************
 
+
 Report Bugs
 ===========
 
-Post bug reports to the issue tracker on GitHub:
+Please post bug reports to the issue tracker on GitHub:
 https://github.com/qscat/qscat/issues
 

--- a/docs/source/manual/others/sample_workflow.rst
+++ b/docs/source/manual/others/sample_workflow.rst
@@ -10,9 +10,10 @@ Sample Workflow
       :local:
       :depth: 3
 
-This section provides a step-by-step guide on how to run a shoreline change analysis using QSCAT with sample data from Agoo, La Union shorelines. The sample data includes shoreline vectors from 1977, 1988, 2010, and 2022. The process includes generating the baseline vectors, merging the shoreline vectors, and running the shoreline change analysis.
 
-According to the :ref:`plugin_required_inputs` section, the QSCAT requires the two following layers:
+This section provides a step-by-step guide on how to run a shoreline change analysis using QSCAT with sample data from the Agoo, La Union shorelines. The sample data includes shoreline vectors from 1977, 1988, 2010, and 2022. The process includes generating the baseline vectors, merging the shoreline vectors, and running the shoreline change analysis.
+
+According to the :ref:`plugin_required_inputs` section, QSCAT requires the following two layers:
 
    #. Shoreline layer
    #. Baseline layer

--- a/docs/source/manual/tabs/about.rst
+++ b/docs/source/manual/tabs/about.rst
@@ -4,7 +4,8 @@
 Tab: About
 **********
 
-The :guilabel:`About Tab` allows you to see the current version of your QSCAT, check for updates, and see some useful links.
+
+The :guilabel:`About Tab` allows you to see the current version of QSCAT, check for updates, and access useful links.
 
 .. only:: html
 

--- a/docs/source/manual/tabs/area_change.rst
+++ b/docs/source/manual/tabs/area_change.rst
@@ -4,7 +4,8 @@
 Tab: Area Change
 ****************
 
-The :guilabel:`Area Change Tab` allows you to estimate the area change between two shoreline vectors for a given polygon layer. The polygon layer can be manually drawn or based on geographic boundaries (e.g., shapefiles of barangay, municipal boundaries), for which this type of analysis may be more meaningful. Monitoring how much coastal land a barangay or municipality has gained or lost is important for coastal planning and management. It is required that the boundary drawn encompasses all shorelines.
+
+The :guilabel:`Area Change Tab` allows you to estimate the area change between two shoreline vectors for a given polygon layer. The polygon layer can be manually drawn or based on geographic boundaries (e.g., shapefiles of barangay or municipal boundaries), for which this type of analysis may be more meaningful. Monitoring how much coastal land a barangay or municipality has gained or lost is important for coastal planning and management. It is required that the drawn boundary encompasses all shorelines.
 
 .. only:: html
 

--- a/docs/source/manual/tabs/automator.rst
+++ b/docs/source/manual/tabs/automator.rst
@@ -4,7 +4,8 @@
 Tab: Automator
 **************
 
-The :guilabel:`Automator Tab` allows you to automate repetitive tasks directly from the plugin such as adding fields to the shoreline layer and baseline layer.
+
+The :guilabel:`Automator Tab` allows you to automate repetitive tasks directly from the plugin, such as adding fields to the shoreline layer and baseline layer.
 
 .. only:: html
 

--- a/docs/source/manual/tabs/forecasting.rst
+++ b/docs/source/manual/tabs/forecasting.rst
@@ -4,7 +4,8 @@
 Tab: Forecasting
 ****************
 
-The :guilabel:`Forecasting Tab` allows you to forecast the shoreline position based on the Kalman Filter algorithm.
+
+The :guilabel:`Forecasting Tab` allows you to forecast the shoreline position using the Kalman Filter algorithm.
 
 .. only:: html
 

--- a/docs/source/manual/tabs/project_settings.rst
+++ b/docs/source/manual/tabs/project_settings.rst
@@ -4,7 +4,8 @@
 Tab: Project Settings
 *********************
 
-The :guilabel:`Project Settings Tab` allows you to configure the plugin for the QGIS project.
+
+The :guilabel:`Project Settings Tab` allows you to configure the plugin settings for the QGIS project.
 
 .. only:: html
 

--- a/docs/source/manual/tabs/shoreline_change.rst
+++ b/docs/source/manual/tabs/shoreline_change.rst
@@ -4,7 +4,8 @@
 Tab: Shoreline Change
 *********************
 
-The :guilabel:`Shoreline Change Tab` allows you to calculate the following shoreline change statistics: (a) Shoreline Change Envelope (SCE), (b) Net Shoreline Movement (NSM), (c) End-Point Rate (EPR), and (d) Linear Regression Rate (LRR). The first three statistics (SCE, NSM, and EPR) require only two shoreline vectors, while LRR requires at least three (3) shoreline vectors to compute the rate of change. SCE and NSM refer to magnitude or distance in meters (m), while EPR and LRR are rate-of-change statistics in meters/year (m/y).
+
+The :guilabel:`Shoreline Change Tab` allows you to calculate the following shoreline change statistics: (a) Shoreline Change Envelope (SCE), (b) Net Shoreline Movement (NSM), (c) End-Point Rate (EPR), and (d) Linear Regression Rate (LRR). The first three statistics (SCE, NSM, and EPR) require only two shoreline vectors, while LRR requires at least three (3) shoreline vectors to compute the rate of change. SCE and NSM refer to magnitude or distance in meters (m), while EPR and LRR are rate-of-change statistics in meters per year (m/y).
 
 .. only:: html
 
@@ -39,7 +40,7 @@ This run requires a transect layer to calculate the selected statistics in the :
 Clip transects
 --------------
 
-By default, the transects are not clipped to the farthest shoreline extent. However, you have the power to choose whether to clip the shorelines by checking this box. The clipping has no effects on the statistics, but it will make seeing statistics' transects easier.
+By default, the transects are not clipped to the farthest shoreline extent. However, you have the power to choose whether to clip the shorelines by checking this box. The clipping has no effect on the statistics, but it will make seeing the statistics' transects easier.
 
 .. _tab_shoreline_change_tsi:
 

--- a/docs/source/manual/tabs/summary_reports.rst
+++ b/docs/source/manual/tabs/summary_reports.rst
@@ -4,7 +4,8 @@
 Tab: Summary Reports
 ********************
 
-The :guilabel:`Summary Reports Tab` allows you to configure the save location, and enable or disable the generation of summary reports. The summary reports are text files that contain the base information and the summary of results of the shoreline change, area change, and forecasting results.
+
+The :guilabel:`Summary Reports Tab` allows you to configure the save location and enable or disable the generation of summary reports. The summary reports are text files that contain the base information and the summary of results for the shoreline change, area change, and forecasting analyses.
 
 .. only:: html
 

--- a/docs/source/manual/tabs/transects.rst
+++ b/docs/source/manual/tabs/transects.rst
@@ -4,7 +4,8 @@
 Tab: Transects
 ***************
 
-The :guilabel:`Transects Tab` allows you to casts the transects.
+
+The :guilabel:`Transects Tab` allows you to cast the transects.
 
 .. only:: html
 

--- a/environment-3.36.1.yml
+++ b/environment-3.36.1.yml
@@ -1,0 +1,13 @@
+name: qgis-3.36.1
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - qgis=3.36.1
+  - pyqt
+  - python=3.10
+  - pip
+  - pip:
+    - pytest
+    - pytest-cov
+    - coremltools>=7.0

--- a/environment-3.36.1.yml
+++ b/environment-3.36.1.yml
@@ -10,4 +10,3 @@ dependencies:
   - pip:
     - pytest
     - pytest-cov
-    - coremltools>=7.0

--- a/qscat/core/tabs/reports.py
+++ b/qscat/core/tabs/reports.py
@@ -74,298 +74,300 @@ class SummaryReport:
 
         project_inputs = self.inputs.project()
 
-        with open(summary_report_file_path, "w", encoding="utf-8") as f:
-            f.write("[PROJECT DETAILS]\n")
-            f.write("\n")
-            f.write("GENERAL:\n")
-            f.write(f'Time generated: {self.summary["datetime"]}\n')
-            f.write(f"Project location: {get_project_dir()}\n")
-            f.write("\n")
-            f.write("PROJECTION:\n")
-            f.write(f'CRS auth id: {project_inputs["crs_id"]}\n')
-            f.write("\n")
-            f.write("AUTHOR:\n")
-            f.write(f'Full name: {project_inputs["author_full_name"]}\n')
-            f.write(f'Affiliation: {project_inputs["author_affiliation"]}\n')
-            f.write(f'Email: {project_inputs["author_email"]}\n')
-            f.write("\n")
-            f.write("[SYSTEM DETAILS]\n")
-            f.write("\n")
-            f.write(f"OS version: {platform.system()} {platform.release()}\n")
-            f.write(f"QGIS version: {Qgis.QGIS_VERSION}\n")
-            f.write(f"QSCAT version: {get_metadata_version()}\n")
-            f.write("\n")
-    
-            return f
-    
-        def shoreline_change(self):
-            """Create a summary report for shoreline change computation."""
-            f = self.create(ComputationType.SHORELINE_CHANGE)
-    
-            shorelines_inputs = self.inputs.shorelines()
-            baseline_inputs = self.inputs.baseline()
-            transects_inputs = self.inputs.transects()
-            shoreline_change_inputs = self.inputs.shoreline_change()
-    
-            uncs = ", ".join([f"{x:.2f}" for x in self.inputs.shorelines_uncs()])
-    
-            f.write("[INPUT PARAMETERS]\n")
-            f.write("\n")
-            f.write("SHORELINES TAB:\n")
-            f.write(f'Layer: {shorelines_inputs["shorelines_layer"].name()}\n')
+        f = open(summary_report_file_path, "w", encoding="utf-8")
+        f.write("[PROJECT DETAILS]\n")
+        f.write("\n")
+        f.write("GENERAL:\n")
+        f.write(f'Time generated: {self.summary["datetime"]}\n')
+        f.write(f"Project location: {get_project_dir()}\n")
+        f.write("\n")
+        f.write("PROJECTION:\n")
+        f.write(f'CRS auth id: {project_inputs["crs_id"]}\n')
+        f.write("\n")
+        f.write("AUTHOR:\n")
+        f.write(f'Full name: {project_inputs["author_full_name"]}\n')
+        f.write(f'Affiliation: {project_inputs["author_affiliation"]}\n')
+        f.write(f'Email: {project_inputs["author_email"]}\n')
+        f.write("\n")
+        f.write("[SYSTEM DETAILS]\n")
+        f.write("\n")
+        f.write(f"OS version: {platform.system()} {platform.release()}\n")
+        f.write(f"QGIS version: {Qgis.QGIS_VERSION}\n")
+        f.write(f"QSCAT version: {get_metadata_version()}\n")
+        f.write("\n")
+
+        return f
+
+    def shoreline_change(self):
+        """Create a summary report for shoreline change computation."""
+        f = self.create(ComputationType.SHORELINE_CHANGE)
+
+        shorelines_inputs = self.inputs.shorelines()
+        baseline_inputs = self.inputs.baseline()
+        transects_inputs = self.inputs.transects()
+        shoreline_change_inputs = self.inputs.shoreline_change()
+
+        uncs = ", ".join([f"{x:.2f}" for x in self.inputs.shorelines_uncs()])
+
+        f.write("[INPUT PARAMETERS]\n")
+        f.write("\n")
+        f.write("SHORELINES TAB:\n")
+        f.write(f'Layer: {shorelines_inputs["shorelines_layer"].name()}\n')
+        f.write(
+            f'Default data uncertainty: {shorelines_inputs["default_data_unc"]}\n'
+        )
+        f.write(f'Date field: {shorelines_inputs["date_field"]}\n')
+        f.write(f'Uncertainty field: {shorelines_inputs["unc_field"]}\n')
+        f.write(f'Dates: {", ".join(self.inputs.shorelines_dates())}\n')
+        f.write(f"Uncertainties: {uncs}\n")
+        f.write("\n")
+
+        if baseline_inputs["is_baseline_placement_sea"]:
+            placement = "Sea or Offshore"
+        elif baseline_inputs["is_baseline_placement_land"]:
+            placement = "Land or Onshore"
+        if baseline_inputs["is_baseline_orientation_land_right"]:
+            orientation = "Land is to the RIGHT"
+        elif baseline_inputs["is_baseline_orientation_land_left"]:
+            orientation = "Land is to the LEFT"
+
+        f.write("BASELINE TAB:\n")
+        f.write(f'Layer: {baseline_inputs["baseline_layer"].name()}\n')
+        f.write(f"Placement: {placement}\n")
+        f.write(f"Orientation: {orientation}\n")
+        f.write("\n")
+        f.write("TRANSECTS TAB:\n")
+        f.write(f'Layer output name: {transects_inputs["layer_output_name"]}\n')
+
+        if transects_inputs["is_by_transect_spacing"]:
+            f.write("Transect count: By transect spacing\n")
             f.write(
-                f'Default data uncertainty: {shorelines_inputs["default_data_unc"]}\n'
+                f'Transect spacing: {transects_inputs["by_transect_spacing"]} meters\n'
             )
-            f.write(f'Date field: {shorelines_inputs["date_field"]}\n')
-            f.write(f'Uncertainty field: {shorelines_inputs["unc_field"]}\n')
-            f.write(f'Dates: {", ".join(self.inputs.shorelines_dates())}\n')
-            f.write(f"Uncertainties: {uncs}\n")
-            f.write("\n")
-    
-            if baseline_inputs["is_baseline_placement_sea"]:
-                placement = "Sea or Offshore"
-            elif baseline_inputs["is_baseline_placement_land"]:
-                placement = "Land or Onshore"
-            if baseline_inputs["is_baseline_orientation_land_right"]:
-                orientation = "Land is to the RIGHT"
-            elif baseline_inputs["is_baseline_orientation_land_left"]:
-                orientation = "Land is to the LEFT"
-    
-            f.write("BASELINE TAB:\n")
-            f.write(f'Layer: {baseline_inputs["baseline_layer"].name()}\n')
-            f.write(f"Placement: {placement}\n")
-            f.write(f"Orientation: {orientation}\n")
-            f.write("\n")
-            f.write("TRANSECTS TAB:\n")
-            f.write(f'Layer output name: {transects_inputs["layer_output_name"]}\n')
-    
-            if transects_inputs["is_by_transect_spacing"]:
-                f.write("Transect count: By transect spacing\n")
-                f.write(
-                    f'Transect spacing: {transects_inputs["by_transect_spacing"]} meters\n'
-                )
-            elif transects_inputs["is_by_number_of_transects"]:
-                f.write("Transect count: By number of transects\n")
-                f.write(
-                    f'Number of transects: {transects_inputs["by_number_of_transects"]} transects\n'
-                )
-            f.write(f'Transect length: {transects_inputs["length"]} meters\n')
+        elif transects_inputs["is_by_number_of_transects"]:
+            f.write("Transect count: By number of transects\n")
             f.write(
-                f'Smoothing distance: {transects_inputs["smoothing_distance"]} meters\n'
+                f'Number of transects: {transects_inputs["by_number_of_transects"]} transects\n'
             )
-    
-            f.write("\n")
-            f.write("SHORELINE CHANGE TAB:\n")
-            f.write(
-                f'Transects layer: {shoreline_change_inputs["transects_layer"].name()}\n'
-            )
-            clip_transects = "Yes" if shoreline_change_inputs["is_clip_transects"] else "No"
-    
-            f.write(f"Clip transects: {clip_transects}\n")
-            if shoreline_change_inputs["is_choose_by_distance"]:
-                f.write("Intersections: Choose by distance\n")
-                if shoreline_change_inputs["is_choose_by_distance_farthest"]:
-                    f.write("By distance: Farthest\n")
-                elif shoreline_change_inputs["is_choose_by_distance_closest"]:
-                    f.write("By distance: Closest\n")
-            elif shoreline_change_inputs["is_choose_by_placement"]:
-                f.write("Intersections: Choose by placement\n")
-                if shoreline_change_inputs["is_choose_by_placement_seaward"]:
-                    f.write("By placement: Seaward\n")
-                elif shoreline_change_inputs["is_choose_by_placement_landward"]:
-                    f.write("By placement: Landward\n")
-    
-            f.write(
-                f'Selected statistics: {", ".join(shoreline_change_inputs["selected_stats"])}\n'
-            )
-            f.write(f'Newest date: {shoreline_change_inputs["newest_date"]}\n')
-            f.write(f'Oldest date: {shoreline_change_inputs["oldest_date"]}\n')
-            f.write(f'Newest year: {shoreline_change_inputs["newest_year"]}\n')
-            f.write(f'Oldest year: {shoreline_change_inputs["oldest_year"]}\n')
-            f.write(
-                f'Confidence interval: {shoreline_change_inputs["confidence_interval"]}\n'
-            )
-            f.write("\n")
-            f.write("[SUMMARY OF RESULTS]\n")
-            f.write("\n")
-            f.write(f'Total no. of transects: {self.summary["num_of_transects"]}\n')
-            f.write("\n")
-    
-            selected_stats = shoreline_change_inputs["selected_stats"]
-    
-            if Statistic.SCE in selected_stats:
-                f.write("SHORELINE CHANGE ENVELOPE (SCE):\n")
-    
-                if self.summary["SCE"]:
-                    f.write(f'Avg. value: {self.summary["SCE_avg"]}\n')
-                    f.write(f'Max. value: {self.summary["SCE_max"]}\n')
-                    f.write(f'Min. value: {self.summary["SCE_min"]}\n')
-                    f.write("\n")
+        f.write(f'Transect length: {transects_inputs["length"]} meters\n')
+        f.write(
+            f'Smoothing distance: {transects_inputs["smoothing_distance"]} meters\n'
+        )
+
+        f.write("\n")
+        f.write("SHORELINE CHANGE TAB:\n")
+        f.write(
+            f'Transects layer: {shoreline_change_inputs["transects_layer"].name()}\n'
+        )
+        clip_transects = "Yes" if shoreline_change_inputs["is_clip_transects"] else "No"
+
+        f.write(f"Clip transects: {clip_transects}\n")
+        if shoreline_change_inputs["is_choose_by_distance"]:
+            f.write("Intersections: Choose by distance\n")
+            if shoreline_change_inputs["is_choose_by_distance_farthest"]:
+                f.write("By distance: Farthest\n")
+            elif shoreline_change_inputs["is_choose_by_distance_closest"]:
+                f.write("By distance: Closest\n")
+        elif shoreline_change_inputs["is_choose_by_placement"]:
+            f.write("Intersections: Choose by placement\n")
+            if shoreline_change_inputs["is_choose_by_placement_seaward"]:
+                f.write("By placement: Seaward\n")
+            elif shoreline_change_inputs["is_choose_by_placement_landward"]:
+                f.write("By placement: Landward\n")
+
+        f.write(
+            f'Selected statistics: {", ".join(shoreline_change_inputs["selected_stats"])}\n'
+        )
+        f.write(f'Newest date: {shoreline_change_inputs["newest_date"]}\n')
+        f.write(f'Oldest date: {shoreline_change_inputs["oldest_date"]}\n')
+        f.write(f'Newest year: {shoreline_change_inputs["newest_year"]}\n')
+        f.write(f'Oldest year: {shoreline_change_inputs["oldest_year"]}\n')
+        f.write(
+            f'Confidence interval: {shoreline_change_inputs["confidence_interval"]}\n'
+        )
+        f.write("\n")
+        f.write("[SUMMARY OF RESULTS]\n")
+        f.write("\n")
+        f.write(f'Total no. of transects: {self.summary["num_of_transects"]}\n')
+        f.write("\n")
+
+        selected_stats = shoreline_change_inputs["selected_stats"]
+
+        if Statistic.SCE in selected_stats:
+            f.write("SHORELINE CHANGE ENVELOPE (SCE):\n")
+
+            if self.summary["SCE"]:
+                f.write(f'Avg. value: {self.summary["SCE_avg"]}\n')
+                f.write(f'Max. value: {self.summary["SCE_max"]}\n')
+                f.write(f'Min. value: {self.summary["SCE_min"]}\n')
+                f.write("\n")
+            else:
+                f.write("SCE is checked but there is no data\n")
+                f.write("\n")
+
+        if Statistic.NSM in selected_stats:
+            f.write("NET SHORELINE MOVEMENT (NSM):\n")
+
+            if self.summary["NSM"]:
+                f.write(f'Avg. distance: {self.summary["NSM_avg"]}\n')
+                f.write("\n")
+
+                if self.summary["NSM_erosion_num_of_transects"] == 0:
+                    f.write("There are no eroding values\n")
                 else:
-                    f.write("SCE is checked but there is no data\n")
+                    f.write("Eroding:\n")
+                    f.write(
+                        f'No. of transects: {self.summary["NSM_erosion_num_of_transects"]}\n'
+                    )
+                    f.write(f'(%) transects: {self.summary["NSM_erosion_pct_transects"]}\n')
+                    f.write(f'Avg. value: {self.summary["NSM_erosion_avg"]}\n')
+                    f.write(f'Max. value: {self.summary["NSM_erosion_max"]}\n')
+                    f.write(f'Min. value: {self.summary["NSM_erosion_min"]}\n')
                     f.write("\n")
-    
-            if Statistic.NSM in selected_stats:
-                f.write("NET SHORELINE MOVEMENT (NSM):\n")
-    
-                if self.summary["NSM"]:
-                    f.write(f'Avg. distance: {self.summary["NSM_avg"]}\n')
-                    f.write("\n")
-    
-                    if self.summary["NSM_erosion_num_of_transects"] == 0:
-                        f.write("There are no eroding values\n")
-                    else:
-                        f.write("Eroding:\n")
-                        f.write(
-                            f'No. of transects: {self.summary["NSM_erosion_num_of_transects"]}\n'
-                        )
-                        f.write(f'(%) transects: {self.summary["NSM_erosion_pct_transects"]}\n')
-                        f.write(f'Avg. value: {self.summary["NSM_erosion_avg"]}\n')
-                        f.write(f'Max. value: {self.summary["NSM_erosion_max"]}\n')
-                        f.write(f'Min. value: {self.summary["NSM_erosion_min"]}\n')
-                        f.write("\n")
-    
-                    if self.summary["NSM_accretion_num_of_transects"] == 0:
-                        f.write("There are no accreting values\n")
-                    else:
-                        f.write("Accreting:\n")
-                        f.write(
-                            f'No. of transects: {self.summary["NSM_accretion_num_of_transects"]}\n'
-                        )
-                        f.write(f'(%) transects: {self.summary["NSM_accretion_pct_transects"]}\n')
-                        f.write(f'Avg. value: {self.summary["NSM_accretion_avg"]}\n')
-                        f.write(f'Max. value: {self.summary["NSM_accretion_max"]}\n')
-                        f.write(f'Min. value: {self.summary["NSM_accretion_min"]}\n')
-                        f.write("\n")
-    
-                    if self.summary["NSM_stable_num_of_transects"] == 0:
-                        f.write("There are no stable values\n")
-                    else:
-                        f.write("Stable:\n")
-                        f.write(
-                            f'No. of transects: {self.summary["NSM_stable_num_of_transects"]}\n'
-                        )
-                        f.write(f'(%) transects: {self.summary["NSM_stable_pct_transects"]}\n')
-                        f.write(f'Avg. value: {self.summary["NSM_stable_avg"]}\n')
-                        f.write(f'Max. value: {self.summary["NSM_stable_max"]}\n')
-                        f.write(f'Min. value: {self.summary["NSM_stable_min"]}\n')
-                        f.write("\n")
+
+                if self.summary["NSM_accretion_num_of_transects"] == 0:
+                    f.write("There are no accreting values\n")
                 else:
-                    f.write("NSM is checked but there is no data\n")
+                    f.write("Accreting:\n")
+                    f.write(
+                        f'No. of transects: {self.summary["NSM_accretion_num_of_transects"]}\n'
+                    )
+                    f.write(f'(%) transects: {self.summary["NSM_accretion_pct_transects"]}\n')
+                    f.write(f'Avg. value: {self.summary["NSM_accretion_avg"]}\n')
+                    f.write(f'Max. value: {self.summary["NSM_accretion_max"]}\n')
+                    f.write(f'Min. value: {self.summary["NSM_accretion_min"]}\n')
                     f.write("\n")
-    
-            if Statistic.EPR in selected_stats:
-                f.write("END POINT RATE (EPR):\n")
-    
-                if self.summary["EPR"]:
-                    f.write(f'Avg. rate: {self.summary["EPR_avg"]}\n')
-                    f.write("\n")
-    
-                    if self.summary["EPR_erosion_num_of_transects"] == 0:
-                        f.write("There are no eroding values\n")
-                    else:
-                        f.write("Eroding:\n")
-                        f.write(
-                            f'No. of transects: {self.summary["EPR_erosion_num_of_transects"]}\n'
-                        )
-                        f.write(f'(%) transects: {self.summary["EPR_erosion_pct_transects"]}\n')
-                        f.write(f'Avg. value: {self.summary["EPR_erosion_avg"]}\n')
-                        f.write(f'Max. value: {self.summary["EPR_erosion_max"]}\n')
-                        f.write(f'Min. value: {self.summary["EPR_erosion_min"]}\n')
-                        f.write("\n")
-                    if self.summary["EPR_accretion_num_of_transects"] == 0:
-                        f.write("There are no accreting values\n")
-                    else:
-                        f.write("Accreting:\n")
-                        f.write(
-                            f'No. of transects: {self.summary["EPR_accretion_num_of_transects"]}\n'
-                        )
-                        f.write(f'(%) transects: {self.summary["EPR_accretion_pct_transects"]}\n')
-                        f.write(f'Avg. value: {self.summary["EPR_accretion_avg"]}\n')
-                        f.write(f'Max. value: {self.summary["EPR_accretion_max"]}\n')
-                        f.write(f'Min. value: {self.summary["EPR_accretion_min"]}\n')
-                        f.write("\n")
-                    if self.summary["EPR_stable_num_of_transects"] == 0:
-                        f.write("There are no stable values\n")
-                    else:
-                        f.write("Stable:\n")
-                        f.write(
-                            f'No. of transects: {self.summary["EPR_stable_num_of_transects"]}\n'
-                        )
-                        f.write(f'(%) transects: {self.summary["EPR_stable_pct_transects"]}\n')
-                        f.write(f'Avg. value: {self.summary["EPR_stable_avg"]}\n')
-                        f.write(f'Max. value: {self.summary["EPR_stable_max"]}\n')
-                        f.write(f'Min. value: {self.summary["EPR_stable_min"]}\n')
-                        f.write("\n")
+
+                if self.summary["NSM_stable_num_of_transects"] == 0:
+                    f.write("There are no stable values\n")
                 else:
-                    f.write("EPR is checked but there is no data\n")
+                    f.write("Stable:\n")
+                    f.write(
+                        f'No. of transects: {self.summary["NSM_stable_num_of_transects"]}\n'
+                    )
+                    f.write(f'(%) transects: {self.summary["NSM_stable_pct_transects"]}\n')
+                    f.write(f'Avg. value: {self.summary["NSM_stable_avg"]}\n')
+                    f.write(f'Max. value: {self.summary["NSM_stable_max"]}\n')
+                    f.write(f'Min. value: {self.summary["NSM_stable_min"]}\n')
                     f.write("\n")
-    
-            if Statistic.LRR in selected_stats:
-                f.write("LINEAR REGRESSION RATE (LRR):\n")
-    
-                if self.summary["LRR"]:
-                    if self.summary["LRR_erosion_num_of_transects"] == 0:
-                        f.write("There are no eroding values\n")
-                    else:
-                        f.write("Eroding:\n")
-                        f.write(
-                            f'No. of transects: {self.summary["LRR_erosion_num_of_transects"]}\n'
-                        )
-                        f.write(f'(%) transects: {self.summary["LRR_erosion_pct_transects"]}\n')
-                        f.write(f'Avg. value: {self.summary["LRR_erosion_avg"]}\n')
-                        f.write(f'Max. value: {self.summary["LRR_erosion_max"]}\n')
-                        f.write(f'Min. value: {self.summary["LRR_erosion_min"]}\n')
-                        f.write("\n")
-    
-                    if self.summary["LRR_accretion_num_of_transects"] == 0:
-                        f.write("There are no accreting values\n")
-                    else:
-                        f.write("Accreting:\n")
-                        f.write(
-                            f'No. of transects: {self.summary["LRR_accretion_num_of_transects"]}\n'
-                        )
-                        f.write(f'(%) transects: {self.summary["LRR_accretion_pct_transects"]}\n')
-                        f.write(f'Avg. value: {self.summary["LRR_accretion_avg"]}\n')
-                        f.write(f'Max. value: {self.summary["LRR_accretion_max"]}\n')
-                        f.write(f'Min. value: {self.summary["LRR_accretion_min"]}\n')
-                        f.write("\n")
+            else:
+                f.write("NSM is checked but there is no data\n")
+                f.write("\n")
+
+        if Statistic.EPR in selected_stats:
+            f.write("END POINT RATE (EPR):\n")
+
+            if self.summary["EPR"]:
+                f.write(f'Avg. rate: {self.summary["EPR_avg"]}\n')
+                f.write("\n")
+
+                if self.summary["EPR_erosion_num_of_transects"] == 0:
+                    f.write("There are no eroding values\n")
                 else:
-                    f.write("LRR is checked but there is no data\n")
+                    f.write("Eroding:\n")
+                    f.write(
+                        f'No. of transects: {self.summary["EPR_erosion_num_of_transects"]}\n'
+                    )
+                    f.write(f'(%) transects: {self.summary["EPR_erosion_pct_transects"]}\n')
+                    f.write(f'Avg. value: {self.summary["EPR_erosion_avg"]}\n')
+                    f.write(f'Max. value: {self.summary["EPR_erosion_max"]}\n')
+                    f.write(f'Min. value: {self.summary["EPR_erosion_min"]}\n')
                     f.write("\n")
-    
-            if Statistic.WLR in selected_stats:
-                f.write("WEIGHTED LINEAR REGRESSION (WLR):\n")
-    
-                if self.summary["WLR"]:
-                    if self.summary["WLR_erosion_num_of_transects"] == 0:
-                        f.write("There are no eroding values\n")
-                    else:
-                        f.write("Eroding:\n")
-                        f.write(
-                            f'No. of transects: {self.summary["WLR_erosion_num_of_transects"]}\n'
-                        )
-                        f.write(f'(%) transects: {self.summary["WLR_erosion_pct_transects"]}\n')
-                        f.write(f'Avg. value: {self.summary["WLR_erosion_avg"]}\n')
-                        f.write(f'Max. value: {self.summary["WLR_erosion_max"]}\n')
-                        f.write(f'Min. value: {self.summary["WLR_erosion_min"]}\n')
-                        f.write("\n")
-    
-                    if self.summary["WLR_accretion_num_of_transects"] == 0:
-                        f.write("There are no accreting values\n")
-                    else:
-                        f.write("Accreting:\n")
-                        f.write(
-                            f'No. of transects: {self.summary["WLR_accretion_num_of_transects"]}\n'
-                        )
-                        f.write(f'(%) transects: {self.summary["WLR_accretion_pct_transects"]}\n')
-                        f.write(f'Avg. value: {self.summary["WLR_accretion_avg"]}\n')
-                        f.write(f'Max. value: {self.summary["WLR_accretion_max"]}\n')
-                        f.write(f'Min. value: {self.summary["WLR_accretion_min"]}\n')
-                        f.write("\n")
+                if self.summary["EPR_accretion_num_of_transects"] == 0:
+                    f.write("There are no accreting values\n")
                 else:
-                    f.write("WLR is checked but there is no data\n")
+                    f.write("Accreting:\n")
+                    f.write(
+                        f'No. of transects: {self.summary["EPR_accretion_num_of_transects"]}\n'
+                    )
+                    f.write(f'(%) transects: {self.summary["EPR_accretion_pct_transects"]}\n')
+                    f.write(f'Avg. value: {self.summary["EPR_accretion_avg"]}\n')
+                    f.write(f'Max. value: {self.summary["EPR_accretion_max"]}\n')
+                    f.write(f'Min. value: {self.summary["EPR_accretion_min"]}\n')
                     f.write("\n")
+                if self.summary["EPR_stable_num_of_transects"] == 0:
+                    f.write("There are no stable values\n")
+                else:
+                    f.write("Stable:\n")
+                    f.write(
+                        f'No. of transects: {self.summary["EPR_stable_num_of_transects"]}\n'
+                    )
+                    f.write(f'(%) transects: {self.summary["EPR_stable_pct_transects"]}\n')
+                    f.write(f'Avg. value: {self.summary["EPR_stable_avg"]}\n')
+                    f.write(f'Max. value: {self.summary["EPR_stable_max"]}\n')
+                    f.write(f'Min. value: {self.summary["EPR_stable_min"]}\n')
+                    f.write("\n")
+            else:
+                f.write("EPR is checked but there is no data\n")
+                f.write("\n")
+
+        if Statistic.LRR in selected_stats:
+            f.write("LINEAR REGRESSION RATE (LRR):\n")
+
+            if self.summary["LRR"]:
+                if self.summary["LRR_erosion_num_of_transects"] == 0:
+                    f.write("There are no eroding values\n")
+                else:
+                    f.write("Eroding:\n")
+                    f.write(
+                        f'No. of transects: {self.summary["LRR_erosion_num_of_transects"]}\n'
+                    )
+                    f.write(f'(%) transects: {self.summary["LRR_erosion_pct_transects"]}\n')
+                    f.write(f'Avg. value: {self.summary["LRR_erosion_avg"]}\n')
+                    f.write(f'Max. value: {self.summary["LRR_erosion_max"]}\n')
+                    f.write(f'Min. value: {self.summary["LRR_erosion_min"]}\n')
+                    f.write("\n")
+
+                if self.summary["LRR_accretion_num_of_transects"] == 0:
+                    f.write("There are no accreting values\n")
+                else:
+                    f.write("Accreting:\n")
+                    f.write(
+                        f'No. of transects: {self.summary["LRR_accretion_num_of_transects"]}\n'
+                    )
+                    f.write(f'(%) transects: {self.summary["LRR_accretion_pct_transects"]}\n')
+                    f.write(f'Avg. value: {self.summary["LRR_accretion_avg"]}\n')
+                    f.write(f'Max. value: {self.summary["LRR_accretion_max"]}\n')
+                    f.write(f'Min. value: {self.summary["LRR_accretion_min"]}\n')
+                    f.write("\n")
+            else:
+                f.write("LRR is checked but there is no data\n")
+                f.write("\n")
+
+        if Statistic.WLR in selected_stats:
+            f.write("WEIGHTED LINEAR REGRESSION (WLR):\n")
+
+            if self.summary["WLR"]:
+                if self.summary["WLR_erosion_num_of_transects"] == 0:
+                    f.write("There are no eroding values\n")
+                else:
+                    f.write("Eroding:\n")
+                    f.write(
+                        f'No. of transects: {self.summary["WLR_erosion_num_of_transects"]}\n'
+                    )
+                    f.write(f'(%) transects: {self.summary["WLR_erosion_pct_transects"]}\n')
+                    f.write(f'Avg. value: {self.summary["WLR_erosion_avg"]}\n')
+                    f.write(f'Max. value: {self.summary["WLR_erosion_max"]}\n')
+                    f.write(f'Min. value: {self.summary["WLR_erosion_min"]}\n')
+                    f.write("\n")
+
+                if self.summary["WLR_accretion_num_of_transects"] == 0:
+                    f.write("There are no accreting values\n")
+                else:
+                    f.write("Accreting:\n")
+                    f.write(
+                        f'No. of transects: {self.summary["WLR_accretion_num_of_transects"]}\n'
+                    )
+                    f.write(f'(%) transects: {self.summary["WLR_accretion_pct_transects"]}\n')
+                    f.write(f'Avg. value: {self.summary["WLR_accretion_avg"]}\n')
+                    f.write(f'Max. value: {self.summary["WLR_accretion_max"]}\n')
+                    f.write(f'Min. value: {self.summary["WLR_accretion_min"]}\n')
+                    f.write("\n")
+            else:
+                f.write("WLR is checked but there is no data\n")
+                f.write("\n")
+
+        f.close()
 
     def area_change(self):
         """Create a summary report for area change computation."""

--- a/qscat/core/tabs/reports.py
+++ b/qscat/core/tabs/reports.py
@@ -195,138 +195,158 @@ class SummaryReport:
 
         if Statistic.SCE in selected_stats:
             f.write("SHORELINE CHANGE ENVELOPE (SCE):\n")
-            f.write(f'Avg. value: {self.summary["SCE_avg"]}\n')
-            f.write(f'Max. value: {self.summary["SCE_max"]}\n')
-            f.write(f'Min. value: {self.summary["SCE_min"]}\n')
-            f.write("\n")
+
+            if self.summary["SCE"] is None:
+                f.write("SCE is checked but there are no data\n")
+            else:
+                f.write(f'Avg. value: {self.summary["SCE_avg"]}\n')
+                f.write(f'Max. value: {self.summary["SCE_max"]}\n')
+                f.write(f'Min. value: {self.summary["SCE_min"]}\n')
+                f.write("\n")
 
         if Statistic.NSM in selected_stats:
             f.write("NET SHORELINE MOVEMENT (NSM):\n")
-            f.write(f'Avg. distance: {self.summary["NSM_avg"]}:\n')
-            f.write("\n")
 
-            if self.summary["NSM_erosion_num_of_transects"] == 0:
-                f.write("There are no eroding values\n")
-            else:
-                f.write("Eroding:\n")
-                f.write(
-                    f'No. of transects: {self.summary["NSM_erosion_num_of_transects"]}\n'
-                )
-                f.write(f'(%) transects: {self.summary["NSM_erosion_pct_transects"]}\n')
-                f.write(f'Avg. value: {self.summary["NSM_erosion_avg"]}\n')
-                f.write(f'Max. value: {self.summary["NSM_erosion_max"]}\n')
-                f.write(f'Min. value: {self.summary["NSM_erosion_min"]}\n')
+            if self.summary["NSM"] is not None:
+                f.write(f'Avg. distance: {self.summary["NSM_avg"]}:\n')
                 f.write("\n")
-            if self.summary["NSM_accretion_num_of_transects"] == 0:
-                f.write("There are no accreting values\n")
+
+                if self.summary["NSM_erosion_num_of_transects"] == 0:
+                    f.write("There are no eroding values\n")
+                else:
+                    f.write("Eroding:\n")
+                    f.write(
+                        f'No. of transects: {self.summary["NSM_erosion_num_of_transects"]}\n'
+                    )
+                    f.write(f'(%) transects: {self.summary["NSM_erosion_pct_transects"]}\n')
+                    f.write(f'Avg. value: {self.summary["NSM_erosion_avg"]}\n')
+                    f.write(f'Max. value: {self.summary["NSM_erosion_max"]}\n')
+                    f.write(f'Min. value: {self.summary["NSM_erosion_min"]}\n')
+                    f.write("\n")
+
+                if self.summary["NSM_accretion_num_of_transects"] == 0:
+                    f.write("There are no accreting values\n")
+                else:
+                    f.write("Accreting:\n")
+                    f.write(
+                        f'No. of transects: {self.summary["NSM_accretion_num_of_transects"]}\n'
+                    )
+                    f.write(f'(%) transects: {self.summary["NSM_accretion_pct_transects"]}\n')
+                    f.write(f'Avg. value: {self.summary["NSM_accretion_avg"]}\n')
+                    f.write(f'Max. value: {self.summary["NSM_accretion_max"]}\n')
+                    f.write(f'Min. value: {self.summary["NSM_accretion_min"]}\n')
+                    f.write("\n")
+
+                if self.summary["NSM_stable_num_of_transects"] == 0:
+                    f.write("There are no stable values\n")
+                else:
+                    f.write("Stable:\n")
+                    f.write(
+                        f'No. of transects: {self.summary["NSM_stable_num_of_transects"]}\n'
+                    )
+                    f.write(f'(%) transects: {self.summary["NSM_stable_pct_transects"]}\n')
+                    f.write(f'Avg. value: {self.summary["NSM_stable_avg"]}\n')
+                    f.write(f'Max. value: {self.summary["NSM_stable_max"]}\n')
+                    f.write(f'Min. value: {self.summary["NSM_stable_min"]}\n')
+                    f.write("\n")
             else:
-                f.write("Accreting:\n")
-                f.write(
-                    f'No. of transects: {self.summary["NSM_accretion_num_of_transects"]}\n'
-                )
-                f.write(f'(%) transects: {self.summary["NSM_accretion_pct_transects"]}\n')
-                f.write(f'Avg. value: {self.summary["NSM_accretion_avg"]}\n')
-                f.write(f'Max. value: {self.summary["NSM_accretion_max"]}\n')
-                f.write(f'Min. value: {self.summary["NSM_accretion_min"]}\n')
-                f.write("\n")
-            if self.summary["NSM_stable_num_of_transects"] == 0:
-                f.write("There are no stable values\n")
-            else:
-                f.write("Stable:\n")
-                f.write(
-                    f'No. of transects: {self.summary["NSM_stable_num_of_transects"]}\n'
-                )
-                f.write(f'(%) transects: {self.summary["NSM_stable_pct_transects"]}\n')
-                f.write(f'Avg. value: {self.summary["NSM_stable_avg"]}\n')
-                f.write(f'Max. value: {self.summary["NSM_stable_max"]}\n')
-                f.write(f'Min. value: {self.summary["NSM_stable_min"]}\n')
-                f.write("\n")
+                f.write("NSM is checked but there are no data\n")
 
         if Statistic.EPR in selected_stats:
             f.write("END POINT RATE (EPR):\n")
-            f.write(f'Avg. rate: {self.summary["EPR_avg"]}\n')
-            f.write("\n")
 
-            if self.summary["EPR_erosion_num_of_transects"] == 0:
-                f.write("There are no eroding values\n")
-            else:
-                f.write("Eroding:\n")
-                f.write(
-                    f'No. of transects: {self.summary["EPR_erosion_num_of_transects"]}\n'
-                )
-                f.write(f'(%) transects: {self.summary["EPR_erosion_pct_transects"]}\n')
-                f.write(f'Avg. value: {self.summary["EPR_erosion_avg"]}\n')
-                f.write(f'Max. value: {self.summary["EPR_erosion_max"]}\n')
-                f.write(f'Min. value: {self.summary["EPR_erosion_min"]}\n')
+            if self.summary["EPR"] is not None:
+                f.write(f'Avg. rate: {self.summary["EPR_avg"]}\n')
                 f.write("\n")
-            if self.summary["EPR_accretion_num_of_transects"] == 0:
-                f.write("There are no accreting values\n")
+
+                if self.summary["EPR_erosion_num_of_transects"] == 0:
+                    f.write("There are no eroding values\n")
+                else:
+                    f.write("Eroding:\n")
+                    f.write(
+                        f'No. of transects: {self.summary["EPR_erosion_num_of_transects"]}\n'
+                    )
+                    f.write(f'(%) transects: {self.summary["EPR_erosion_pct_transects"]}\n')
+                    f.write(f'Avg. value: {self.summary["EPR_erosion_avg"]}\n')
+                    f.write(f'Max. value: {self.summary["EPR_erosion_max"]}\n')
+                    f.write(f'Min. value: {self.summary["EPR_erosion_min"]}\n')
+                    f.write("\n")
+                if self.summary["EPR_accretion_num_of_transects"] == 0:
+                    f.write("There are no accreting values\n")
+                else:
+                    f.write("Accreting:\n")
+                    f.write(
+                        f'No. of transects: {self.summary["EPR_accretion_num_of_transects"]}\n'
+                    )
+                    f.write(f'(%) transects: {self.summary["EPR_accretion_pct_transects"]}\n')
+                    f.write(f'Avg. value: {self.summary["EPR_accretion_avg"]}\n')
+                    f.write(f'Max. value: {self.summary["EPR_accretion_max"]}\n')
+                    f.write(f'Min. value: {self.summary["EPR_accretion_min"]}\n')
+                    f.write("\n")
+                if self.summary["EPR_stable_num_of_transects"] == 0:
+                    f.write("There are no stable values\n")
+                else:
+                    f.write("Stable:\n")
+                    f.write(
+                        f'No. of transects: {self.summary["EPR_stable_num_of_transects"]}\n'
+                    )
+                    f.write(f'(%) transects: {self.summary["EPR_stable_pct_transects"]}\n')
+                    f.write(f'Avg. value: {self.summary["EPR_stable_avg"]}\n')
+                    f.write(f'Max. value: {self.summary["EPR_stable_max"]}\n')
+                    f.write(f'Min. value: {self.summary["EPR_stable_min"]}\n')
+                    f.write("\n")
             else:
-                f.write("Accreting:\n")
-                f.write(
-                    f'No. of transects: {self.summary["EPR_accretion_num_of_transects"]}\n'
-                )
-                f.write(f'(%) transects: {self.summary["EPR_accretion_pct_transects"]}\n')
-                f.write(f'Avg. value: {self.summary["EPR_accretion_avg"]}\n')
-                f.write(f'Max. value: {self.summary["EPR_accretion_max"]}\n')
-                f.write(f'Min. value: {self.summary["EPR_accretion_min"]}\n')
-                f.write("\n")
-            if self.summary["EPR_stable_num_of_transects"] == 0:
-                f.write("There are no stable values\n")
-            else:
-                f.write("Stable:\n")
-                f.write(
-                    f'No. of transects: {self.summary["EPR_stable_num_of_transects"]}\n'
-                )
-                f.write(f'(%) transects: {self.summary["EPR_stable_pct_transects"]}\n')
-                f.write(f'Avg. value: {self.summary["EPR_stable_avg"]}\n')
-                f.write(f'Max. value: {self.summary["EPR_stable_max"]}\n')
-                f.write(f'Min. value: {self.summary["EPR_stable_min"]}\n')
-                f.write("\n")
+                f.write("EPR is checked but there are no data\n")
 
         if Statistic.LRR in selected_stats:
             f.write("LINEAR REGRESSION RATE (LRR):\n")
 
-            f.write("Eroding:\n")
-            f.write(
-                f'No. of transects: {self.summary["LRR_erosion_num_of_transects"]}\n'
-            )
-            f.write(f'(%) transects: {self.summary["LRR_erosion_pct_transects"]}\n')
-            f.write(f'Avg. value: {self.summary["LRR_erosion_avg"]}\n')
-            f.write(f'Max. value: {self.summary["LRR_erosion_max"]}\n')
-            f.write(f'Min. value: {self.summary["LRR_erosion_min"]}\n')
-            f.write("\n")
-            f.write("Accreting:\n")
-            f.write(
-                f'No. of transects: {self.summary["LRR_accretion_num_of_transects"]}\n'
-            )
-            f.write(f'(%) transects: {self.summary["LRR_accretion_pct_transects"]}\n')
-            f.write(f'Avg. value: {self.summary["LRR_accretion_avg"]}\n')
-            f.write(f'Max. value: {self.summary["LRR_accretion_max"]}\n')
-            f.write(f'Min. value: {self.summary["LRR_accretion_min"]}\n')
-            f.write("\n")
+            if self.summary["LRR"] is not None:
+                f.write("Eroding:\n")
+                f.write(
+                    f'No. of transects: {self.summary["LRR_erosion_num_of_transects"]}\n'
+                )
+                f.write(f'(%) transects: {self.summary["LRR_erosion_pct_transects"]}\n')
+                f.write(f'Avg. value: {self.summary["LRR_erosion_avg"]}\n')
+                f.write(f'Max. value: {self.summary["LRR_erosion_max"]}\n')
+                f.write(f'Min. value: {self.summary["LRR_erosion_min"]}\n')
+                f.write("\n")
+                f.write("Accreting:\n")
+                f.write(
+                    f'No. of transects: {self.summary["LRR_accretion_num_of_transects"]}\n'
+                )
+                f.write(f'(%) transects: {self.summary["LRR_accretion_pct_transects"]}\n')
+                f.write(f'Avg. value: {self.summary["LRR_accretion_avg"]}\n')
+                f.write(f'Max. value: {self.summary["LRR_accretion_max"]}\n')
+                f.write(f'Min. value: {self.summary["LRR_accretion_min"]}\n')
+                f.write("\n")
+            else:
+                f.write("LRR is checked but there are no data\n")
 
         if Statistic.WLR in selected_stats:
             f.write("WEIGHTED LINEAR REGRESSION (WLR):\n")
 
-            f.write("Eroding:\n")
-            f.write(
-                f'No. of transects: {self.summary["WLR_erosion_num_of_transects"]}\n'
-            )
-            f.write(f'(%) transects: {self.summary["WLR_erosion_pct_transects"]}\n')
-            f.write(f'Avg. value: {self.summary["WLR_erosion_avg"]}\n')
-            f.write(f'Max. value: {self.summary["WLR_erosion_max"]}\n')
-            f.write(f'Min. value: {self.summary["WLR_erosion_min"]}\n')
-            f.write("\n")
-            f.write("Accreting:\n")
-            f.write(
-                f'No. of transects: {self.summary["WLR_accretion_num_of_transects"]}\n'
-            )
-            f.write(f'(%) transects: {self.summary["WLR_accretion_pct_transects"]}\n')
-            f.write(f'Avg. value: {self.summary["WLR_accretion_avg"]}\n')
-            f.write(f'Max. value: {self.summary["WLR_accretion_max"]}\n')
-            f.write(f'Min. value: {self.summary["WLR_accretion_min"]}\n')
-            f.write("\n")
+            if self.summary["WLR"] is not None:
+                f.write("Eroding:\n")
+                f.write(
+                    f'No. of transects: {self.summary["WLR_erosion_num_of_transects"]}\n'
+                )
+                f.write(f'(%) transects: {self.summary["WLR_erosion_pct_transects"]}\n')
+                f.write(f'Avg. value: {self.summary["WLR_erosion_avg"]}\n')
+                f.write(f'Max. value: {self.summary["WLR_erosion_max"]}\n')
+                f.write(f'Min. value: {self.summary["WLR_erosion_min"]}\n')
+                f.write("\n")
+                f.write("Accreting:\n")
+                f.write(
+                    f'No. of transects: {self.summary["WLR_accretion_num_of_transects"]}\n'
+                )
+                f.write(f'(%) transects: {self.summary["WLR_accretion_pct_transects"]}\n')
+                f.write(f'Avg. value: {self.summary["WLR_accretion_avg"]}\n')
+                f.write(f'Max. value: {self.summary["WLR_accretion_max"]}\n')
+                f.write(f'Min. value: {self.summary["WLR_accretion_min"]}\n')
+                f.write("\n")
+            else:
+                f.write("WLR is checked but there are no data\n")
 
         f.close()
 

--- a/qscat/core/tabs/reports.py
+++ b/qscat/core/tabs/reports.py
@@ -74,295 +74,298 @@ class SummaryReport:
 
         project_inputs = self.inputs.project()
 
-        f = open(summary_report_file_path, "w", encoding="utf-8")
-        f.write("[PROJECT DETAILS]\n")
-        f.write("\n")
-        f.write("GENERAL:\n")
-        f.write(f'Time generated: {self.summary["datetime"]}\n')
-        f.write(f"Project location: {get_project_dir()}\n")
-        f.write("\n")
-        f.write("PROJECTION:\n")
-        f.write(f'CRS auth id: {project_inputs["crs_id"]}\n')
-        f.write("\n")
-        f.write("AUTHOR:\n")
-        f.write(f'Full name: {project_inputs["author_full_name"]}\n')
-        f.write(f'Affiliation: {project_inputs["author_affiliation"]}\n')
-        f.write(f'Email: {project_inputs["author_email"]}\n')
-        f.write("\n")
-        f.write("[SYSTEM DETAILS]\n")
-        f.write("\n")
-        f.write(f"OS version: {platform.system()} {platform.release()}\n")
-        f.write(f"QGIS version: {Qgis.QGIS_VERSION}\n")
-        f.write(f"QSCAT version: {get_metadata_version()}\n")
-        f.write("\n")
-
-        return f
-
-    def shoreline_change(self):
-        """Create a summary report for shoreline change computation."""
-        f = self.create(ComputationType.SHORELINE_CHANGE)
-
-        shorelines_inputs = self.inputs.shorelines()
-        baseline_inputs = self.inputs.baseline()
-        transects_inputs = self.inputs.transects()
-        shoreline_change_inputs = self.inputs.shoreline_change()
-
-        uncs = ", ".join([f"{x:.2f}" for x in self.inputs.shorelines_uncs()])
-
-        f.write("[INPUT PARAMETERS]\n")
-        f.write("\n")
-        f.write("SHORELINES TAB:\n")
-        f.write(f'Layer: {shorelines_inputs["shorelines_layer"].name()}\n')
-        f.write(
-            f'Default data uncertainty: {shorelines_inputs["default_data_unc"]}\n'
-        )
-        f.write(f'Date field: {shorelines_inputs["date_field"]}\n')
-        f.write(f'Uncertainty field: {shorelines_inputs["unc_field"]}\n')
-        f.write(f'Dates: {", ".join(self.inputs.shorelines_dates())}\n')
-        f.write(f"Uncertainties: {uncs}\n")
-        f.write("\n")
-
-        if baseline_inputs["is_baseline_placement_sea"]:
-            placement = "Sea or Offshore"
-        elif baseline_inputs["is_baseline_placement_land"]:
-            placement = "Land or Onshore"
-        if baseline_inputs["is_baseline_orientation_land_right"]:
-            orientation = "Land is to the RIGHT"
-        elif baseline_inputs["is_baseline_orientation_land_left"]:
-            orientation = "Land is to the LEFT"
-
-        f.write("BASELINE TAB:\n")
-        f.write(f'Layer: {baseline_inputs["baseline_layer"].name()}\n')
-        f.write(f"Placement: {placement}\n")
-        f.write(f"Orientation: {orientation}\n")
-        f.write("\n")
-        f.write("TRANSECTS TAB:\n")
-        f.write(f'Layer output name: {transects_inputs["layer_output_name"]}\n')
-
-        if transects_inputs["is_by_transect_spacing"]:
-            f.write("Transect count: By transect spacing\n")
+        with open(summary_report_file_path, "w", encoding="utf-8") as f:
+            f.write("[PROJECT DETAILS]\n")
+            f.write("\n")
+            f.write("GENERAL:\n")
+            f.write(f'Time generated: {self.summary["datetime"]}\n')
+            f.write(f"Project location: {get_project_dir()}\n")
+            f.write("\n")
+            f.write("PROJECTION:\n")
+            f.write(f'CRS auth id: {project_inputs["crs_id"]}\n')
+            f.write("\n")
+            f.write("AUTHOR:\n")
+            f.write(f'Full name: {project_inputs["author_full_name"]}\n')
+            f.write(f'Affiliation: {project_inputs["author_affiliation"]}\n')
+            f.write(f'Email: {project_inputs["author_email"]}\n')
+            f.write("\n")
+            f.write("[SYSTEM DETAILS]\n")
+            f.write("\n")
+            f.write(f"OS version: {platform.system()} {platform.release()}\n")
+            f.write(f"QGIS version: {Qgis.QGIS_VERSION}\n")
+            f.write(f"QSCAT version: {get_metadata_version()}\n")
+            f.write("\n")
+    
+            return f
+    
+        def shoreline_change(self):
+            """Create a summary report for shoreline change computation."""
+            f = self.create(ComputationType.SHORELINE_CHANGE)
+    
+            shorelines_inputs = self.inputs.shorelines()
+            baseline_inputs = self.inputs.baseline()
+            transects_inputs = self.inputs.transects()
+            shoreline_change_inputs = self.inputs.shoreline_change()
+    
+            uncs = ", ".join([f"{x:.2f}" for x in self.inputs.shorelines_uncs()])
+    
+            f.write("[INPUT PARAMETERS]\n")
+            f.write("\n")
+            f.write("SHORELINES TAB:\n")
+            f.write(f'Layer: {shorelines_inputs["shorelines_layer"].name()}\n')
             f.write(
-                f'Transect spacing: {transects_inputs["by_transect_spacing"]} meters\n'
+                f'Default data uncertainty: {shorelines_inputs["default_data_unc"]}\n'
             )
-        elif transects_inputs["is_by_number_of_transects"]:
-            f.write("Transect count: By number of transects\n")
+            f.write(f'Date field: {shorelines_inputs["date_field"]}\n')
+            f.write(f'Uncertainty field: {shorelines_inputs["unc_field"]}\n')
+            f.write(f'Dates: {", ".join(self.inputs.shorelines_dates())}\n')
+            f.write(f"Uncertainties: {uncs}\n")
+            f.write("\n")
+    
+            if baseline_inputs["is_baseline_placement_sea"]:
+                placement = "Sea or Offshore"
+            elif baseline_inputs["is_baseline_placement_land"]:
+                placement = "Land or Onshore"
+            if baseline_inputs["is_baseline_orientation_land_right"]:
+                orientation = "Land is to the RIGHT"
+            elif baseline_inputs["is_baseline_orientation_land_left"]:
+                orientation = "Land is to the LEFT"
+    
+            f.write("BASELINE TAB:\n")
+            f.write(f'Layer: {baseline_inputs["baseline_layer"].name()}\n')
+            f.write(f"Placement: {placement}\n")
+            f.write(f"Orientation: {orientation}\n")
+            f.write("\n")
+            f.write("TRANSECTS TAB:\n")
+            f.write(f'Layer output name: {transects_inputs["layer_output_name"]}\n')
+    
+            if transects_inputs["is_by_transect_spacing"]:
+                f.write("Transect count: By transect spacing\n")
+                f.write(
+                    f'Transect spacing: {transects_inputs["by_transect_spacing"]} meters\n'
+                )
+            elif transects_inputs["is_by_number_of_transects"]:
+                f.write("Transect count: By number of transects\n")
+                f.write(
+                    f'Number of transects: {transects_inputs["by_number_of_transects"]} transects\n'
+                )
+            f.write(f'Transect length: {transects_inputs["length"]} meters\n')
             f.write(
-                f'Number of transects: {transects_inputs["by_number_of_transects"]} transects\n'
+                f'Smoothing distance: {transects_inputs["smoothing_distance"]} meters\n'
             )
-        f.write(f'Transect length: {transects_inputs["length"]} meters\n')
-        f.write(
-            f'Smoothing distance: {transects_inputs["smoothing_distance"]} meters\n'
-        )
-
-        f.write("\n")
-        f.write("SHORELINE CHANGE TAB:\n")
-        f.write(
-            f'Transects layer: {shoreline_change_inputs["transects_layer"].name()}\n'
-        )
-        clip_transects = "Yes" if shoreline_change_inputs["is_clip_transects"] else "No"
-
-        f.write(f"Clip transects: {clip_transects}\n")
-        if shoreline_change_inputs["is_choose_by_distance"]:
-            f.write("Intersections: Choose by distance\n")
-            if shoreline_change_inputs["is_choose_by_distance_farthest"]:
-                f.write("By distance: Farthest\n")
-            elif shoreline_change_inputs["is_choose_by_distance_closest"]:
-                f.write("By distance: Closest\n")
-        elif shoreline_change_inputs["is_choose_by_placement"]:
-            f.write("Intersections: Choose by placement\n")
-            if shoreline_change_inputs["is_choose_by_placement_seaward"]:
-                f.write("By placement: Seaward\n")
-            elif shoreline_change_inputs["is_choose_by_placement_landward"]:
-                f.write("By placement: Landward\n")
-
-        f.write(
-            f'Selected statistics: {", ".join(shoreline_change_inputs["selected_stats"])}\n'
-        )
-        f.write(f'Newest date: {shoreline_change_inputs["newest_date"]}\n')
-        f.write(f'Oldest date: {shoreline_change_inputs["oldest_date"]}\n')
-        f.write(f'Newest year: {shoreline_change_inputs["newest_year"]}\n')
-        f.write(f'Oldest year: {shoreline_change_inputs["oldest_year"]}\n')
-        f.write(
-            f'Confidence interval: {shoreline_change_inputs["confidence_interval"]}\n'
-        )
-        f.write("\n")
-        f.write("[SUMMARY OF RESULTS]\n")
-        f.write("\n")
-        f.write(f'Total no. of transects: {self.summary["num_of_transects"]}\n')
-        f.write("\n")
-
-        selected_stats = shoreline_change_inputs["selected_stats"]
-
-        if Statistic.SCE in selected_stats:
-            f.write("SHORELINE CHANGE ENVELOPE (SCE):\n")
-
-            if self.summary["SCE"]:
-                f.write(f'Avg. value: {self.summary["SCE_avg"]}\n')
-                f.write(f'Max. value: {self.summary["SCE_max"]}\n')
-                f.write(f'Min. value: {self.summary["SCE_min"]}\n')
-                f.write("\n")
-            else:
-                f.write("SCE is checked but there are no data\n")
-
-        if Statistic.NSM in selected_stats:
-            f.write("NET SHORELINE MOVEMENT (NSM):\n")
-
-            if self.summary["NSM"]:
-                f.write(f'Avg. distance: {self.summary["NSM_avg"]}:\n')
-                f.write("\n")
-
-                if self.summary["NSM_erosion_num_of_transects"] == 0:
-                    f.write("There are no eroding values\n")
-                else:
-                    f.write("Eroding:\n")
-                    f.write(
-                        f'No. of transects: {self.summary["NSM_erosion_num_of_transects"]}\n'
-                    )
-                    f.write(f'(%) transects: {self.summary["NSM_erosion_pct_transects"]}\n')
-                    f.write(f'Avg. value: {self.summary["NSM_erosion_avg"]}\n')
-                    f.write(f'Max. value: {self.summary["NSM_erosion_max"]}\n')
-                    f.write(f'Min. value: {self.summary["NSM_erosion_min"]}\n')
+    
+            f.write("\n")
+            f.write("SHORELINE CHANGE TAB:\n")
+            f.write(
+                f'Transects layer: {shoreline_change_inputs["transects_layer"].name()}\n'
+            )
+            clip_transects = "Yes" if shoreline_change_inputs["is_clip_transects"] else "No"
+    
+            f.write(f"Clip transects: {clip_transects}\n")
+            if shoreline_change_inputs["is_choose_by_distance"]:
+                f.write("Intersections: Choose by distance\n")
+                if shoreline_change_inputs["is_choose_by_distance_farthest"]:
+                    f.write("By distance: Farthest\n")
+                elif shoreline_change_inputs["is_choose_by_distance_closest"]:
+                    f.write("By distance: Closest\n")
+            elif shoreline_change_inputs["is_choose_by_placement"]:
+                f.write("Intersections: Choose by placement\n")
+                if shoreline_change_inputs["is_choose_by_placement_seaward"]:
+                    f.write("By placement: Seaward\n")
+                elif shoreline_change_inputs["is_choose_by_placement_landward"]:
+                    f.write("By placement: Landward\n")
+    
+            f.write(
+                f'Selected statistics: {", ".join(shoreline_change_inputs["selected_stats"])}\n'
+            )
+            f.write(f'Newest date: {shoreline_change_inputs["newest_date"]}\n')
+            f.write(f'Oldest date: {shoreline_change_inputs["oldest_date"]}\n')
+            f.write(f'Newest year: {shoreline_change_inputs["newest_year"]}\n')
+            f.write(f'Oldest year: {shoreline_change_inputs["oldest_year"]}\n')
+            f.write(
+                f'Confidence interval: {shoreline_change_inputs["confidence_interval"]}\n'
+            )
+            f.write("\n")
+            f.write("[SUMMARY OF RESULTS]\n")
+            f.write("\n")
+            f.write(f'Total no. of transects: {self.summary["num_of_transects"]}\n')
+            f.write("\n")
+    
+            selected_stats = shoreline_change_inputs["selected_stats"]
+    
+            if Statistic.SCE in selected_stats:
+                f.write("SHORELINE CHANGE ENVELOPE (SCE):\n")
+    
+                if self.summary["SCE"]:
+                    f.write(f'Avg. value: {self.summary["SCE_avg"]}\n')
+                    f.write(f'Max. value: {self.summary["SCE_max"]}\n')
+                    f.write(f'Min. value: {self.summary["SCE_min"]}\n')
                     f.write("\n")
-
-                if self.summary["NSM_accretion_num_of_transects"] == 0:
-                    f.write("There are no accreting values\n")
                 else:
-                    f.write("Accreting:\n")
-                    f.write(
-                        f'No. of transects: {self.summary["NSM_accretion_num_of_transects"]}\n'
-                    )
-                    f.write(f'(%) transects: {self.summary["NSM_accretion_pct_transects"]}\n')
-                    f.write(f'Avg. value: {self.summary["NSM_accretion_avg"]}\n')
-                    f.write(f'Max. value: {self.summary["NSM_accretion_max"]}\n')
-                    f.write(f'Min. value: {self.summary["NSM_accretion_min"]}\n')
+                    f.write("SCE is checked but there is no data\n")
                     f.write("\n")
-
-                if self.summary["NSM_stable_num_of_transects"] == 0:
-                    f.write("There are no stable values\n")
+    
+            if Statistic.NSM in selected_stats:
+                f.write("NET SHORELINE MOVEMENT (NSM):\n")
+    
+                if self.summary["NSM"]:
+                    f.write(f'Avg. distance: {self.summary["NSM_avg"]}\n')
+                    f.write("\n")
+    
+                    if self.summary["NSM_erosion_num_of_transects"] == 0:
+                        f.write("There are no eroding values\n")
+                    else:
+                        f.write("Eroding:\n")
+                        f.write(
+                            f'No. of transects: {self.summary["NSM_erosion_num_of_transects"]}\n'
+                        )
+                        f.write(f'(%) transects: {self.summary["NSM_erosion_pct_transects"]}\n')
+                        f.write(f'Avg. value: {self.summary["NSM_erosion_avg"]}\n')
+                        f.write(f'Max. value: {self.summary["NSM_erosion_max"]}\n')
+                        f.write(f'Min. value: {self.summary["NSM_erosion_min"]}\n')
+                        f.write("\n")
+    
+                    if self.summary["NSM_accretion_num_of_transects"] == 0:
+                        f.write("There are no accreting values\n")
+                    else:
+                        f.write("Accreting:\n")
+                        f.write(
+                            f'No. of transects: {self.summary["NSM_accretion_num_of_transects"]}\n'
+                        )
+                        f.write(f'(%) transects: {self.summary["NSM_accretion_pct_transects"]}\n')
+                        f.write(f'Avg. value: {self.summary["NSM_accretion_avg"]}\n')
+                        f.write(f'Max. value: {self.summary["NSM_accretion_max"]}\n')
+                        f.write(f'Min. value: {self.summary["NSM_accretion_min"]}\n')
+                        f.write("\n")
+    
+                    if self.summary["NSM_stable_num_of_transects"] == 0:
+                        f.write("There are no stable values\n")
+                    else:
+                        f.write("Stable:\n")
+                        f.write(
+                            f'No. of transects: {self.summary["NSM_stable_num_of_transects"]}\n'
+                        )
+                        f.write(f'(%) transects: {self.summary["NSM_stable_pct_transects"]}\n')
+                        f.write(f'Avg. value: {self.summary["NSM_stable_avg"]}\n')
+                        f.write(f'Max. value: {self.summary["NSM_stable_max"]}\n')
+                        f.write(f'Min. value: {self.summary["NSM_stable_min"]}\n')
+                        f.write("\n")
                 else:
-                    f.write("Stable:\n")
-                    f.write(
-                        f'No. of transects: {self.summary["NSM_stable_num_of_transects"]}\n'
-                    )
-                    f.write(f'(%) transects: {self.summary["NSM_stable_pct_transects"]}\n')
-                    f.write(f'Avg. value: {self.summary["NSM_stable_avg"]}\n')
-                    f.write(f'Max. value: {self.summary["NSM_stable_max"]}\n')
-                    f.write(f'Min. value: {self.summary["NSM_stable_min"]}\n')
+                    f.write("NSM is checked but there is no data\n")
                     f.write("\n")
-            else:
-                f.write("NSM is checked but there are no data\n")
-
-        if Statistic.EPR in selected_stats:
-            f.write("END POINT RATE (EPR):\n")
-
-            if self.summary["EPR"]:
-                f.write(f'Avg. rate: {self.summary["EPR_avg"]}\n')
-                f.write("\n")
-
-                if self.summary["EPR_erosion_num_of_transects"] == 0:
-                    f.write("There are no eroding values\n")
+    
+            if Statistic.EPR in selected_stats:
+                f.write("END POINT RATE (EPR):\n")
+    
+                if self.summary["EPR"]:
+                    f.write(f'Avg. rate: {self.summary["EPR_avg"]}\n')
+                    f.write("\n")
+    
+                    if self.summary["EPR_erosion_num_of_transects"] == 0:
+                        f.write("There are no eroding values\n")
+                    else:
+                        f.write("Eroding:\n")
+                        f.write(
+                            f'No. of transects: {self.summary["EPR_erosion_num_of_transects"]}\n'
+                        )
+                        f.write(f'(%) transects: {self.summary["EPR_erosion_pct_transects"]}\n')
+                        f.write(f'Avg. value: {self.summary["EPR_erosion_avg"]}\n')
+                        f.write(f'Max. value: {self.summary["EPR_erosion_max"]}\n')
+                        f.write(f'Min. value: {self.summary["EPR_erosion_min"]}\n')
+                        f.write("\n")
+                    if self.summary["EPR_accretion_num_of_transects"] == 0:
+                        f.write("There are no accreting values\n")
+                    else:
+                        f.write("Accreting:\n")
+                        f.write(
+                            f'No. of transects: {self.summary["EPR_accretion_num_of_transects"]}\n'
+                        )
+                        f.write(f'(%) transects: {self.summary["EPR_accretion_pct_transects"]}\n')
+                        f.write(f'Avg. value: {self.summary["EPR_accretion_avg"]}\n')
+                        f.write(f'Max. value: {self.summary["EPR_accretion_max"]}\n')
+                        f.write(f'Min. value: {self.summary["EPR_accretion_min"]}\n')
+                        f.write("\n")
+                    if self.summary["EPR_stable_num_of_transects"] == 0:
+                        f.write("There are no stable values\n")
+                    else:
+                        f.write("Stable:\n")
+                        f.write(
+                            f'No. of transects: {self.summary["EPR_stable_num_of_transects"]}\n'
+                        )
+                        f.write(f'(%) transects: {self.summary["EPR_stable_pct_transects"]}\n')
+                        f.write(f'Avg. value: {self.summary["EPR_stable_avg"]}\n')
+                        f.write(f'Max. value: {self.summary["EPR_stable_max"]}\n')
+                        f.write(f'Min. value: {self.summary["EPR_stable_min"]}\n')
+                        f.write("\n")
                 else:
-                    f.write("Eroding:\n")
-                    f.write(
-                        f'No. of transects: {self.summary["EPR_erosion_num_of_transects"]}\n'
-                    )
-                    f.write(f'(%) transects: {self.summary["EPR_erosion_pct_transects"]}\n')
-                    f.write(f'Avg. value: {self.summary["EPR_erosion_avg"]}\n')
-                    f.write(f'Max. value: {self.summary["EPR_erosion_max"]}\n')
-                    f.write(f'Min. value: {self.summary["EPR_erosion_min"]}\n')
+                    f.write("EPR is checked but there is no data\n")
                     f.write("\n")
-                if self.summary["EPR_accretion_num_of_transects"] == 0:
-                    f.write("There are no accreting values\n")
+    
+            if Statistic.LRR in selected_stats:
+                f.write("LINEAR REGRESSION RATE (LRR):\n")
+    
+                if self.summary["LRR"]:
+                    if self.summary["LRR_erosion_num_of_transects"] == 0:
+                        f.write("There are no eroding values\n")
+                    else:
+                        f.write("Eroding:\n")
+                        f.write(
+                            f'No. of transects: {self.summary["LRR_erosion_num_of_transects"]}\n'
+                        )
+                        f.write(f'(%) transects: {self.summary["LRR_erosion_pct_transects"]}\n')
+                        f.write(f'Avg. value: {self.summary["LRR_erosion_avg"]}\n')
+                        f.write(f'Max. value: {self.summary["LRR_erosion_max"]}\n')
+                        f.write(f'Min. value: {self.summary["LRR_erosion_min"]}\n')
+                        f.write("\n")
+    
+                    if self.summary["LRR_accretion_num_of_transects"] == 0:
+                        f.write("There are no accreting values\n")
+                    else:
+                        f.write("Accreting:\n")
+                        f.write(
+                            f'No. of transects: {self.summary["LRR_accretion_num_of_transects"]}\n'
+                        )
+                        f.write(f'(%) transects: {self.summary["LRR_accretion_pct_transects"]}\n')
+                        f.write(f'Avg. value: {self.summary["LRR_accretion_avg"]}\n')
+                        f.write(f'Max. value: {self.summary["LRR_accretion_max"]}\n')
+                        f.write(f'Min. value: {self.summary["LRR_accretion_min"]}\n')
+                        f.write("\n")
                 else:
-                    f.write("Accreting:\n")
-                    f.write(
-                        f'No. of transects: {self.summary["EPR_accretion_num_of_transects"]}\n'
-                    )
-                    f.write(f'(%) transects: {self.summary["EPR_accretion_pct_transects"]}\n')
-                    f.write(f'Avg. value: {self.summary["EPR_accretion_avg"]}\n')
-                    f.write(f'Max. value: {self.summary["EPR_accretion_max"]}\n')
-                    f.write(f'Min. value: {self.summary["EPR_accretion_min"]}\n')
+                    f.write("LRR is checked but there is no data\n")
                     f.write("\n")
-                if self.summary["EPR_stable_num_of_transects"] == 0:
-                    f.write("There are no stable values\n")
+    
+            if Statistic.WLR in selected_stats:
+                f.write("WEIGHTED LINEAR REGRESSION (WLR):\n")
+    
+                if self.summary["WLR"]:
+                    if self.summary["WLR_erosion_num_of_transects"] == 0:
+                        f.write("There are no eroding values\n")
+                    else:
+                        f.write("Eroding:\n")
+                        f.write(
+                            f'No. of transects: {self.summary["WLR_erosion_num_of_transects"]}\n'
+                        )
+                        f.write(f'(%) transects: {self.summary["WLR_erosion_pct_transects"]}\n')
+                        f.write(f'Avg. value: {self.summary["WLR_erosion_avg"]}\n')
+                        f.write(f'Max. value: {self.summary["WLR_erosion_max"]}\n')
+                        f.write(f'Min. value: {self.summary["WLR_erosion_min"]}\n')
+                        f.write("\n")
+    
+                    if self.summary["WLR_accretion_num_of_transects"] == 0:
+                        f.write("There are no accreting values\n")
+                    else:
+                        f.write("Accreting:\n")
+                        f.write(
+                            f'No. of transects: {self.summary["WLR_accretion_num_of_transects"]}\n'
+                        )
+                        f.write(f'(%) transects: {self.summary["WLR_accretion_pct_transects"]}\n')
+                        f.write(f'Avg. value: {self.summary["WLR_accretion_avg"]}\n')
+                        f.write(f'Max. value: {self.summary["WLR_accretion_max"]}\n')
+                        f.write(f'Min. value: {self.summary["WLR_accretion_min"]}\n')
+                        f.write("\n")
                 else:
-                    f.write("Stable:\n")
-                    f.write(
-                        f'No. of transects: {self.summary["EPR_stable_num_of_transects"]}\n'
-                    )
-                    f.write(f'(%) transects: {self.summary["EPR_stable_pct_transects"]}\n')
-                    f.write(f'Avg. value: {self.summary["EPR_stable_avg"]}\n')
-                    f.write(f'Max. value: {self.summary["EPR_stable_max"]}\n')
-                    f.write(f'Min. value: {self.summary["EPR_stable_min"]}\n')
+                    f.write("WLR is checked but there is no data\n")
                     f.write("\n")
-            else:
-                f.write("EPR is checked but there are no data\n")
-
-        if Statistic.LRR in selected_stats:
-            f.write("LINEAR REGRESSION RATE (LRR):\n")
-
-            if self.summary["LRR"]:
-                if self.summary["LRR_erosion_num_of_transects"] == 0:
-                    f.write("There are no eroding values\n")
-                else:
-                    f.write("Eroding:\n")
-                    f.write(
-                        f'No. of transects: {self.summary["LRR_erosion_num_of_transects"]}\n'
-                    )
-                    f.write(f'(%) transects: {self.summary["LRR_erosion_pct_transects"]}\n')
-                    f.write(f'Avg. value: {self.summary["LRR_erosion_avg"]}\n')
-                    f.write(f'Max. value: {self.summary["LRR_erosion_max"]}\n')
-                    f.write(f'Min. value: {self.summary["LRR_erosion_min"]}\n')
-                    f.write("\n")
-
-                if self.summary["LRR_accretion_num_of_transects"] == 0:
-                    f.write("There are no accreting values\n")
-                else:
-                    f.write("Accreting:\n")
-                    f.write(
-                        f'No. of transects: {self.summary["LRR_accretion_num_of_transects"]}\n'
-                    )
-                    f.write(f'(%) transects: {self.summary["LRR_accretion_pct_transects"]}\n')
-                    f.write(f'Avg. value: {self.summary["LRR_accretion_avg"]}\n')
-                    f.write(f'Max. value: {self.summary["LRR_accretion_max"]}\n')
-                    f.write(f'Min. value: {self.summary["LRR_accretion_min"]}\n')
-                    f.write("\n")
-            else:
-                f.write("LRR is checked but there are no data\n")
-
-        if Statistic.WLR in selected_stats:
-            f.write("WEIGHTED LINEAR REGRESSION (WLR):\n")
-
-            if self.summary["WLR"]:
-                if self.summary["WLR_erosion_num_of_transects"] == 0:
-                    f.write("There are no eroding values\n")
-                else:
-                    f.write("Eroding:\n")
-                    f.write(
-                        f'No. of transects: {self.summary["WLR_erosion_num_of_transects"]}\n'
-                    )
-                    f.write(f'(%) transects: {self.summary["WLR_erosion_pct_transects"]}\n')
-                    f.write(f'Avg. value: {self.summary["WLR_erosion_avg"]}\n')
-                    f.write(f'Max. value: {self.summary["WLR_erosion_max"]}\n')
-                    f.write(f'Min. value: {self.summary["WLR_erosion_min"]}\n')
-                    f.write("\n")
-
-                if self.summary["WLR_accretion_num_of_transects"] == 0:
-                    f.write("There are no accreting values\n")
-                else:
-                    f.write("Accreting:\n")
-                    f.write(
-                        f'No. of transects: {self.summary["WLR_accretion_num_of_transects"]}\n'
-                    )
-                    f.write(f'(%) transects: {self.summary["WLR_accretion_pct_transects"]}\n')
-                    f.write(f'Avg. value: {self.summary["WLR_accretion_avg"]}\n')
-                    f.write(f'Max. value: {self.summary["WLR_accretion_max"]}\n')
-                    f.write(f'Min. value: {self.summary["WLR_accretion_min"]}\n')
-                    f.write("\n")
-            else:
-                f.write("WLR is checked but there are no data\n")
-
-        f.close()
 
     def area_change(self):
         """Create a summary report for area change computation."""

--- a/qscat/core/tabs/reports.py
+++ b/qscat/core/tabs/reports.py
@@ -205,66 +205,84 @@ class SummaryReport:
             f.write(f'Avg. distance: {self.summary["NSM_avg"]}:\n')
             f.write("\n")
 
-            f.write("Eroding:\n")
-            f.write(
-                f'No. of transects: {self.summary["NSM_erosion_num_of_transects"]}\n'
-            )
-            f.write(f'(%) transects: {self.summary["NSM_erosion_pct_transects"]}\n')
-            f.write(f'Avg. value: {self.summary["NSM_erosion_avg"]}\n')
-            f.write(f'Max. value: {self.summary["NSM_erosion_max"]}\n')
-            f.write(f'Min. value: {self.summary["NSM_erosion_min"]}\n')
-            f.write("\n")
-            f.write("Accreting:\n")
-            f.write(
-                f'No. of transects: {self.summary["NSM_accretion_num_of_transects"]}\n'
-            )
-            f.write(f'(%) transects: {self.summary["NSM_accretion_pct_transects"]}\n')
-            f.write(f'Avg. value: {self.summary["NSM_accretion_avg"]}\n')
-            f.write(f'Max. value: {self.summary["NSM_accretion_max"]}\n')
-            f.write(f'Min. value: {self.summary["NSM_accretion_min"]}\n')
-            f.write("\n")
-            f.write("Stable:\n")
-            f.write(
-                f'No. of transects: {self.summary["NSM_stable_num_of_transects"]}\n'
-            )
-            f.write(f'(%) transects: {self.summary["NSM_stable_pct_transects"]}\n')
-            f.write(f'Avg. value: {self.summary["NSM_stable_avg"]}\n')
-            f.write(f'Max. value: {self.summary["NSM_stable_max"]}\n')
-            f.write(f'Min. value: {self.summary["NSM_stable_min"]}\n')
-            f.write("\n")
+            if self.summary["NSM_erosion_num_of_transects"] == 0:
+                f.write("There are no eroding values\n")
+            else:
+                f.write("Eroding:\n")
+                f.write(
+                    f'No. of transects: {self.summary["NSM_erosion_num_of_transects"]}\n'
+                )
+                f.write(f'(%) transects: {self.summary["NSM_erosion_pct_transects"]}\n')
+                f.write(f'Avg. value: {self.summary["NSM_erosion_avg"]}\n')
+                f.write(f'Max. value: {self.summary["NSM_erosion_max"]}\n')
+                f.write(f'Min. value: {self.summary["NSM_erosion_min"]}\n')
+                f.write("\n")
+            if self.summary["NSM_accretion_num_of_transects"] == 0:
+                f.write("There are no accreting values\n")
+            else:
+                f.write("Accreting:\n")
+                f.write(
+                    f'No. of transects: {self.summary["NSM_accretion_num_of_transects"]}\n'
+                )
+                f.write(f'(%) transects: {self.summary["NSM_accretion_pct_transects"]}\n')
+                f.write(f'Avg. value: {self.summary["NSM_accretion_avg"]}\n')
+                f.write(f'Max. value: {self.summary["NSM_accretion_max"]}\n')
+                f.write(f'Min. value: {self.summary["NSM_accretion_min"]}\n')
+                f.write("\n")
+            if self.summary["NSM_stable_num_of_transects"] == 0:
+                f.write("There are no stable values\n")
+            else:
+                f.write("Stable:\n")
+                f.write(
+                    f'No. of transects: {self.summary["NSM_stable_num_of_transects"]}\n'
+                )
+                f.write(f'(%) transects: {self.summary["NSM_stable_pct_transects"]}\n')
+                f.write(f'Avg. value: {self.summary["NSM_stable_avg"]}\n')
+                f.write(f'Max. value: {self.summary["NSM_stable_max"]}\n')
+                f.write(f'Min. value: {self.summary["NSM_stable_min"]}\n')
+                f.write("\n")
 
         if Statistic.EPR in selected_stats:
             f.write("END POINT RATE (EPR):\n")
             f.write(f'Avg. rate: {self.summary["EPR_avg"]}\n')
             f.write("\n")
 
-            f.write("Eroding:\n")
-            f.write(
-                f'No. of transects: {self.summary["EPR_erosion_num_of_transects"]}\n'
-            )
-            f.write(f'(%) transects: {self.summary["EPR_erosion_pct_transects"]}\n')
-            f.write(f'Avg. value: {self.summary["EPR_erosion_avg"]}\n')
-            f.write(f'Max. value: {self.summary["EPR_erosion_max"]}\n')
-            f.write(f'Min. value: {self.summary["EPR_erosion_min"]}\n')
-            f.write("\n")
-            f.write("Accreting:\n")
-            f.write(
-                f'No. of transects: {self.summary["EPR_accretion_num_of_transects"]}\n'
-            )
-            f.write(f'(%) transects: {self.summary["EPR_accretion_pct_transects"]}\n')
-            f.write(f'Avg. value: {self.summary["EPR_accretion_avg"]}\n')
-            f.write(f'Max. value: {self.summary["EPR_accretion_max"]}\n')
-            f.write(f'Min. value: {self.summary["EPR_accretion_min"]}\n')
-            f.write("\n")
-            f.write("Stable:\n")
-            f.write(
-                f'No. of transects: {self.summary["EPR_stable_num_of_transects"]}\n'
-            )
-            f.write(f'(%) transects: {self.summary["EPR_stable_pct_transects"]}\n')
-            f.write(f'Avg. value: {self.summary["EPR_stable_avg"]}\n')
-            f.write(f'Max. value: {self.summary["EPR_stable_max"]}\n')
-            f.write(f'Min. value: {self.summary["EPR_stable_min"]}\n')
-            f.write("\n")
+            if self.summary["EPR_erosion_num_of_transects"] == 0:
+                f.write("There are no eroding values\n")
+            else:
+                f.write("Eroding:\n")
+                f.write(
+                    f'No. of transects: {self.summary["EPR_erosion_num_of_transects"]}\n'
+                )
+                f.write(f'(%) transects: {self.summary["EPR_erosion_pct_transects"]}\n')
+                f.write(f'Avg. value: {self.summary["EPR_erosion_avg"]}\n')
+                f.write(f'Max. value: {self.summary["EPR_erosion_max"]}\n')
+                f.write(f'Min. value: {self.summary["EPR_erosion_min"]}\n')
+                f.write("\n")
+            if self.summary["EPR_accretion_num_of_transects"] == 0:
+                f.write("There are no accreting values\n")
+            else:
+                f.write("Accreting:\n")
+                f.write(
+                    f'No. of transects: {self.summary["EPR_accretion_num_of_transects"]}\n'
+                )
+                f.write(f'(%) transects: {self.summary["EPR_accretion_pct_transects"]}\n')
+                f.write(f'Avg. value: {self.summary["EPR_accretion_avg"]}\n')
+                f.write(f'Max. value: {self.summary["EPR_accretion_max"]}\n')
+                f.write(f'Min. value: {self.summary["EPR_accretion_min"]}\n')
+                f.write("\n")
+            if self.summary["EPR_stable_num_of_transects"] == 0:
+                f.write("There are no stable values\n")
+            else:
+                f.write("Stable:\n")
+                f.write(
+                    f'No. of transects: {self.summary["EPR_stable_num_of_transects"]}\n'
+                )
+                f.write(f'(%) transects: {self.summary["EPR_stable_pct_transects"]}\n')
+                f.write(f'Avg. value: {self.summary["EPR_stable_avg"]}\n')
+                f.write(f'Max. value: {self.summary["EPR_stable_max"]}\n')
+                f.write(f'Min. value: {self.summary["EPR_stable_min"]}\n')
+                f.write("\n")
 
         if Statistic.LRR in selected_stats:
             f.write("LINEAR REGRESSION RATE (LRR):\n")

--- a/qscat/core/tabs/reports.py
+++ b/qscat/core/tabs/reports.py
@@ -196,18 +196,18 @@ class SummaryReport:
         if Statistic.SCE in selected_stats:
             f.write("SHORELINE CHANGE ENVELOPE (SCE):\n")
 
-            if self.summary["SCE"] is None:
-                f.write("SCE is checked but there are no data\n")
-            else:
+            if self.summary["SCE"]:
                 f.write(f'Avg. value: {self.summary["SCE_avg"]}\n')
                 f.write(f'Max. value: {self.summary["SCE_max"]}\n')
                 f.write(f'Min. value: {self.summary["SCE_min"]}\n')
                 f.write("\n")
+            else:
+                f.write("SCE is checked but there are no data\n")
 
         if Statistic.NSM in selected_stats:
             f.write("NET SHORELINE MOVEMENT (NSM):\n")
 
-            if self.summary["NSM"] is not None:
+            if self.summary["NSM"]:
                 f.write(f'Avg. distance: {self.summary["NSM_avg"]}:\n')
                 f.write("\n")
 
@@ -255,7 +255,7 @@ class SummaryReport:
         if Statistic.EPR in selected_stats:
             f.write("END POINT RATE (EPR):\n")
 
-            if self.summary["EPR"] is not None:
+            if self.summary["EPR"]:
                 f.write(f'Avg. rate: {self.summary["EPR_avg"]}\n')
                 f.write("\n")
 
@@ -301,50 +301,64 @@ class SummaryReport:
         if Statistic.LRR in selected_stats:
             f.write("LINEAR REGRESSION RATE (LRR):\n")
 
-            if self.summary["LRR"] is not None:
-                f.write("Eroding:\n")
-                f.write(
-                    f'No. of transects: {self.summary["LRR_erosion_num_of_transects"]}\n'
-                )
-                f.write(f'(%) transects: {self.summary["LRR_erosion_pct_transects"]}\n')
-                f.write(f'Avg. value: {self.summary["LRR_erosion_avg"]}\n')
-                f.write(f'Max. value: {self.summary["LRR_erosion_max"]}\n')
-                f.write(f'Min. value: {self.summary["LRR_erosion_min"]}\n')
-                f.write("\n")
-                f.write("Accreting:\n")
-                f.write(
-                    f'No. of transects: {self.summary["LRR_accretion_num_of_transects"]}\n'
-                )
-                f.write(f'(%) transects: {self.summary["LRR_accretion_pct_transects"]}\n')
-                f.write(f'Avg. value: {self.summary["LRR_accretion_avg"]}\n')
-                f.write(f'Max. value: {self.summary["LRR_accretion_max"]}\n')
-                f.write(f'Min. value: {self.summary["LRR_accretion_min"]}\n')
-                f.write("\n")
+            if self.summary["LRR"]:
+                if self.summary["LRR_erosion_num_of_transects"] == 0:
+                    f.write("There are no eroding values\n")
+                else:
+                    f.write("Eroding:\n")
+                    f.write(
+                        f'No. of transects: {self.summary["LRR_erosion_num_of_transects"]}\n'
+                    )
+                    f.write(f'(%) transects: {self.summary["LRR_erosion_pct_transects"]}\n')
+                    f.write(f'Avg. value: {self.summary["LRR_erosion_avg"]}\n')
+                    f.write(f'Max. value: {self.summary["LRR_erosion_max"]}\n')
+                    f.write(f'Min. value: {self.summary["LRR_erosion_min"]}\n')
+                    f.write("\n")
+
+                if self.summary["LRR_accretion_num_of_transects"] == 0:
+                    f.write("There are no accreting values\n")
+                else:
+                    f.write("Accreting:\n")
+                    f.write(
+                        f'No. of transects: {self.summary["LRR_accretion_num_of_transects"]}\n'
+                    )
+                    f.write(f'(%) transects: {self.summary["LRR_accretion_pct_transects"]}\n')
+                    f.write(f'Avg. value: {self.summary["LRR_accretion_avg"]}\n')
+                    f.write(f'Max. value: {self.summary["LRR_accretion_max"]}\n')
+                    f.write(f'Min. value: {self.summary["LRR_accretion_min"]}\n')
+                    f.write("\n")
             else:
                 f.write("LRR is checked but there are no data\n")
 
         if Statistic.WLR in selected_stats:
             f.write("WEIGHTED LINEAR REGRESSION (WLR):\n")
 
-            if self.summary["WLR"] is not None:
-                f.write("Eroding:\n")
-                f.write(
-                    f'No. of transects: {self.summary["WLR_erosion_num_of_transects"]}\n'
-                )
-                f.write(f'(%) transects: {self.summary["WLR_erosion_pct_transects"]}\n')
-                f.write(f'Avg. value: {self.summary["WLR_erosion_avg"]}\n')
-                f.write(f'Max. value: {self.summary["WLR_erosion_max"]}\n')
-                f.write(f'Min. value: {self.summary["WLR_erosion_min"]}\n')
-                f.write("\n")
-                f.write("Accreting:\n")
-                f.write(
-                    f'No. of transects: {self.summary["WLR_accretion_num_of_transects"]}\n'
-                )
-                f.write(f'(%) transects: {self.summary["WLR_accretion_pct_transects"]}\n')
-                f.write(f'Avg. value: {self.summary["WLR_accretion_avg"]}\n')
-                f.write(f'Max. value: {self.summary["WLR_accretion_max"]}\n')
-                f.write(f'Min. value: {self.summary["WLR_accretion_min"]}\n')
-                f.write("\n")
+            if self.summary["WLR"]:
+                if self.summary["WLR_erosion_num_of_transects"] == 0:
+                    f.write("There are no eroding values\n")
+                else:
+                    f.write("Eroding:\n")
+                    f.write(
+                        f'No. of transects: {self.summary["WLR_erosion_num_of_transects"]}\n'
+                    )
+                    f.write(f'(%) transects: {self.summary["WLR_erosion_pct_transects"]}\n')
+                    f.write(f'Avg. value: {self.summary["WLR_erosion_avg"]}\n')
+                    f.write(f'Max. value: {self.summary["WLR_erosion_max"]}\n')
+                    f.write(f'Min. value: {self.summary["WLR_erosion_min"]}\n')
+                    f.write("\n")
+
+                if self.summary["WLR_accretion_num_of_transects"] == 0:
+                    f.write("There are no accreting values\n")
+                else:
+                    f.write("Accreting:\n")
+                    f.write(
+                        f'No. of transects: {self.summary["WLR_accretion_num_of_transects"]}\n'
+                    )
+                    f.write(f'(%) transects: {self.summary["WLR_accretion_pct_transects"]}\n')
+                    f.write(f'Avg. value: {self.summary["WLR_accretion_avg"]}\n')
+                    f.write(f'Max. value: {self.summary["WLR_accretion_max"]}\n')
+                    f.write(f'Min. value: {self.summary["WLR_accretion_min"]}\n')
+                    f.write("\n")
             else:
                 f.write("WLR is checked but there are no data\n")
 

--- a/qscat/core/tabs/shoreline_change.py
+++ b/qscat/core/tabs/shoreline_change.py
@@ -311,7 +311,7 @@ class ShorelineChange:
                 NSM_e = [x for x in NSM if x < -unc]
                 erosion_count = len(NSM_e)
                 summary["NSM_erosion_num_of_transects"] = erosion_count
-                
+
                 if NSM_e:
                     summary["NSM_erosion_pct_transects"] = (
                         f"{(erosion_count / len(NSM)) * 100:.2f} %"
@@ -323,7 +323,7 @@ class ShorelineChange:
                 NSM_a = [x for x in NSM if x > unc]
                 accretion_count = len(NSM_a)
                 summary["NSM_accretion_num_of_transects"] = accretion_count
-                
+
                 if NSM_a:
                     summary["NSM_accretion_pct_transects"] = (
                         f"{(accretion_count / len(NSM)) * 100:.2f} %"
@@ -402,7 +402,7 @@ class ShorelineChange:
                 LRR_e = [x for x in LRR if x < 0]
                 erosion_count = len(LRR_e)
                 summary["LRR_erosion_num_of_transects"] = erosion_count
-                
+
                 if LRR_e:
                     summary["LRR_erosion_pct_transects"] = (
                         f"{(erosion_count / len(LRR)) * 100:.2f} %"
@@ -414,7 +414,7 @@ class ShorelineChange:
                 LRR_a = [x for x in LRR if x >= 0]
                 accretion_count = len(LRR_a)
                 summary["LRR_accretion_num_of_transects"] = accretion_count
-                
+
                 if LRR_a:
                     summary["LRR_accretion_pct_transects"] = (
                         f"{(accretion_count / len(LRR)) * 100:.2f} %"
@@ -431,7 +431,7 @@ class ShorelineChange:
             if WLR:
                 summary["WLR"] = True
                 summary["WLR_avg"] = round(sum(WLR) / len(WLR), 2)
-        
+
                 WLR_e = [x for x in WLR if x < 0]
                 erosion_count = len(WLR_e)
                 summary["WLR_erosion_num_of_transects"] = erosion_count
@@ -447,7 +447,7 @@ class ShorelineChange:
                 WLR_a = [x for x in WLR if x >= 0]
                 accretion_count = len(WLR_a)
                 summary["WLR_accretion_num_of_transects"] = accretion_count
-                
+
                 if WLR_a:
                     summary["WLR_accretion_pct_transects"] = (
                         f"{(accretion_count / len(WLR)) * 100:.2f} %"

--- a/qscat/core/tabs/shoreline_change.py
+++ b/qscat/core/tabs/shoreline_change.py
@@ -306,9 +306,10 @@ class ShorelineChange:
             summary["NSM_erosion_pct_transects"] = (
                 f"{(erosion_count / len(NSM)) * 100:.2f} %"
             )
-            summary["NSM_erosion_avg"] = round(sum(NSM_e) / len(NSM_e), 2)
-            summary["NSM_erosion_max"] = round(max(NSM_e), 2)
-            summary["NSM_erosion_min"] = round(min(NSM_e), 2)
+            if NSM_e:
+                summary["NSM_erosion_avg"] = round(sum(NSM_e) / len(NSM_e), 2)
+                summary["NSM_erosion_max"] = round(max(NSM_e), 2)
+                summary["NSM_erosion_min"] = round(min(NSM_e), 2)
 
             NSM_a = [x for x in NSM if x > unc]
             accretion_count = len(NSM_a)
@@ -316,9 +317,10 @@ class ShorelineChange:
             summary["NSM_accretion_pct_transects"] = (
                 f"{(accretion_count / len(NSM)) * 100:.2f} %"
             )
-            summary["NSM_accretion_avg"] = round(sum(NSM_a) / len(NSM_a), 2)
-            summary["NSM_accretion_max"] = round(max(NSM_a), 2)
-            summary["NSM_accretion_min"] = round(min(NSM_a), 2)
+            if NSM_a:
+                summary["NSM_accretion_avg"] = round(sum(NSM_a) / len(NSM_a), 2)
+                summary["NSM_accretion_max"] = round(max(NSM_a), 2)
+                summary["NSM_accretion_min"] = round(min(NSM_a), 2)
 
             NSM_s = [x for x in NSM if x >= -unc and x <= unc]
             stable_count = len(NSM_s)
@@ -326,9 +328,10 @@ class ShorelineChange:
             summary["NSM_stable_pct_transects"] = (
                 f"{(stable_count / len(NSM)) * 100:.2f} %"
             )
-            summary["NSM_stable_avg"] = round(sum(NSM_s) / len(NSM_s), 2)
-            summary["NSM_stable_max"] = round(max(NSM_s), 2)
-            summary["NSM_stable_min"] = round(min(NSM_s), 2)
+            if NSM_s:
+                summary["NSM_stable_avg"] = round(sum(NSM_s) / len(NSM_s), 2)
+                summary["NSM_stable_max"] = round(max(NSM_s), 2)
+                summary["NSM_stable_min"] = round(min(NSM_s), 2)
 
         if Statistic.EPR in self.shoreline_change_inputs["selected_stats"]:
             EPR = stat_values[Statistic.EPR]
@@ -341,9 +344,10 @@ class ShorelineChange:
             summary["EPR_erosion_pct_transects"] = (
                 f"{(erosion_count / len(EPR)) * 100:.2f} %"
             )
-            summary["EPR_erosion_avg"] = round(sum(EPR_e) / len(EPR_e), 2)
-            summary["EPR_erosion_max"] = round(max(EPR_e), 2)
-            summary["EPR_erosion_min"] = round(min(EPR_e), 2)
+            if EPR_e:
+                summary["EPR_erosion_avg"] = round(sum(EPR_e) / len(EPR_e), 2)
+                summary["EPR_erosion_max"] = round(max(EPR_e), 2)
+                summary["EPR_erosion_min"] = round(min(EPR_e), 2)
 
             EPR_a = [x for x in EPR if x > unc]
             accretion_count = len(EPR_a)
@@ -351,9 +355,10 @@ class ShorelineChange:
             summary["EPR_accretion_pct_transects"] = (
                 f"{(accretion_count / len(EPR)) * 100:.2f} %"
             )
-            summary["EPR_accretion_avg"] = round(sum(EPR_a) / len(EPR_a), 2)
-            summary["EPR_accretion_max"] = round(max(EPR_a), 2)
-            summary["EPR_accretion_min"] = round(min(EPR_a), 2)
+            if EPR_a:
+                summary["EPR_accretion_avg"] = round(sum(EPR_a) / len(EPR_a), 2)
+                summary["EPR_accretion_max"] = round(max(EPR_a), 2)
+                summary["EPR_accretion_min"] = round(min(EPR_a), 2)
 
             EPR_s = [x for x in EPR if x >= -unc and x <= unc]
             stable_count = len(EPR_s)
@@ -361,9 +366,10 @@ class ShorelineChange:
             summary["EPR_stable_pct_transects"] = (
                 f"{(stable_count / len(EPR)) * 100:.2f} %"
             )
-            summary["EPR_stable_avg"] = round(sum(EPR_s) / len(EPR_s), 2)
-            summary["EPR_stable_max"] = round(max(EPR_s), 2)
-            summary["EPR_stable_min"] = round(min(EPR_s), 2)
+            if EPR_s:
+                summary["EPR_stable_avg"] = round(sum(EPR_s) / len(EPR_s), 2)
+                summary["EPR_stable_max"] = round(max(EPR_s), 2)
+                summary["EPR_stable_min"] = round(min(EPR_s), 2)
 
         if Statistic.LRR in self.shoreline_change_inputs["selected_stats"]:
             LRR = stat_values[Statistic.LRR]

--- a/qscat/core/tabs/shoreline_change.py
+++ b/qscat/core/tabs/shoreline_change.py
@@ -293,11 +293,12 @@ class ShorelineChange:
             SCE = stat_values[Statistic.SCE]
 
             if SCE:
+                summary["SCE"] = True
                 summary["SCE_avg"] = round(sum(SCE) / len(SCE), 2)
                 summary["SCE_max"] = round(max(SCE), 2)
                 summary["SCE_min"] = round(min(SCE), 2)
             else:
-                summary["SCE"] = None
+                summary["SCE"] = False
 
         if Statistic.NSM in self.shoreline_change_inputs["selected_stats"]:
             NSM = stat_values[Statistic.NSM]
@@ -449,7 +450,7 @@ class ShorelineChange:
                 summary["WLR_accretion_pct_transects"] = (
                     f"{(accretion_count / len(WLR)) * 100:.2f} %"
                 )
-                
+
                 if WLR_a:
                     summary["WLR_accretion_avg"] = round(sum(WLR_a) / len(WLR_a), 2)
                     summary["WLR_accretion_max"] = round(max(WLR_a), 2)

--- a/qscat/core/tabs/shoreline_change.py
+++ b/qscat/core/tabs/shoreline_change.py
@@ -402,11 +402,11 @@ class ShorelineChange:
                 LRR_e = [x for x in LRR if x < 0]
                 erosion_count = len(LRR_e)
                 summary["LRR_erosion_num_of_transects"] = erosion_count
-                summary["LRR_erosion_pct_transects"] = (
-                    f"{(erosion_count / len(LRR)) * 100:.2f} %"
-                )
-
+                
                 if LRR_e:
+                    summary["LRR_erosion_pct_transects"] = (
+                        f"{(erosion_count / len(LRR)) * 100:.2f} %"
+                    )
                     summary["LRR_erosion_avg"] = round(sum(LRR_e) / len(LRR_e), 2)
                     summary["LRR_erosion_max"] = round(max(LRR_e), 2)
                     summary["LRR_erosion_min"] = round(min(LRR_e), 2)
@@ -414,11 +414,11 @@ class ShorelineChange:
                 LRR_a = [x for x in LRR if x >= 0]
                 accretion_count = len(LRR_a)
                 summary["LRR_accretion_num_of_transects"] = accretion_count
-                summary["LRR_accretion_pct_transects"] = (
-                    f"{(accretion_count / len(LRR)) * 100:.2f} %"
-                )
-
+                
                 if LRR_a:
+                    summary["LRR_accretion_pct_transects"] = (
+                        f"{(accretion_count / len(LRR)) * 100:.2f} %"
+                    )
                     summary["LRR_accretion_avg"] = round(sum(LRR_a) / len(LRR_a), 2)
                     summary["LRR_accretion_max"] = round(max(LRR_a), 2)
                     summary["LRR_accretion_min"] = round(min(LRR_a), 2)
@@ -435,11 +435,11 @@ class ShorelineChange:
                 WLR_e = [x for x in WLR if x < 0]
                 erosion_count = len(WLR_e)
                 summary["WLR_erosion_num_of_transects"] = erosion_count
-                summary["WLR_erosion_pct_transects"] = (
-                    f"{(erosion_count / len(WLR)) * 100:.2f} %"
-                )
 
                 if WLR_e:
+                    summary["WLR_erosion_pct_transects"] = (
+                        f"{(erosion_count / len(WLR)) * 100:.2f} %"
+                    )
                     summary["WLR_erosion_avg"] = round(sum(WLR_e) / len(WLR_e), 2)
                     summary["WLR_erosion_max"] = round(max(WLR_e), 2)
                     summary["WLR_erosion_min"] = round(min(WLR_e), 2)
@@ -447,11 +447,11 @@ class ShorelineChange:
                 WLR_a = [x for x in WLR if x >= 0]
                 accretion_count = len(WLR_a)
                 summary["WLR_accretion_num_of_transects"] = accretion_count
-                summary["WLR_accretion_pct_transects"] = (
-                    f"{(accretion_count / len(WLR)) * 100:.2f} %"
-                )
-
+                
                 if WLR_a:
+                    summary["WLR_accretion_pct_transects"] = (
+                        f"{(accretion_count / len(WLR)) * 100:.2f} %"
+                    )
                     summary["WLR_accretion_avg"] = round(sum(WLR_a) / len(WLR_a), 2)
                     summary["WLR_accretion_max"] = round(max(WLR_a), 2)
                     summary["WLR_accretion_min"] = round(min(WLR_a), 2)

--- a/qscat/core/tabs/shoreline_change.py
+++ b/qscat/core/tabs/shoreline_change.py
@@ -303,6 +303,7 @@ class ShorelineChange:
             NSM = stat_values[Statistic.NSM]
 
             if NSM:
+                summary["NSM"] = True
                 unc = self.shoreline_change_inputs["highest_unc"]
                 summary["NSM_avg"] = round(sum(NSM) / len(NSM), 2)
 
@@ -333,6 +334,7 @@ class ShorelineChange:
                 NSM_s = [x for x in NSM if x >= -unc and x <= unc]
                 stable_count = len(NSM_s)
                 summary["NSM_stable_num_of_transects"] = stable_count
+
                 if NSM_s:
                     summary["NSM_stable_pct_transects"] = (
                         f"{(stable_count / len(NSM)) * 100:.2f} %"
@@ -341,18 +343,20 @@ class ShorelineChange:
                     summary["NSM_stable_max"] = round(max(NSM_s), 2)
                     summary["NSM_stable_min"] = round(min(NSM_s), 2)
             else:
-                summary["NSM"] = None
+                summary["NSM"] = False
 
         if Statistic.EPR in self.shoreline_change_inputs["selected_stats"]:
             EPR = stat_values[Statistic.EPR]
 
             if EPR:
+                summary["EPR"] = True
                 unc = self.shoreline_change_inputs["epr_unc"]
                 summary["EPR_avg"] = round(sum(EPR) / len(EPR), 2)
 
                 EPR_e = [x for x in EPR if x < -unc]
                 erosion_count = len(EPR_e)
                 summary["EPR_erosion_num_of_transects"] = erosion_count
+
                 if EPR_e:
                     summary["EPR_erosion_pct_transects"] = (
                         f"{(erosion_count / len(EPR)) * 100:.2f} %"
@@ -364,6 +368,7 @@ class ShorelineChange:
                 EPR_a = [x for x in EPR if x > unc]
                 accretion_count = len(EPR_a)
                 summary["EPR_accretion_num_of_transects"] = accretion_count
+
                 if EPR_a:
                     summary["EPR_accretion_pct_transects"] = (
                         f"{(accretion_count / len(EPR)) * 100:.2f} %"
@@ -375,6 +380,7 @@ class ShorelineChange:
                 EPR_s = [x for x in EPR if x >= -unc and x <= unc]
                 stable_count = len(EPR_s)
                 summary["EPR_stable_num_of_transects"] = stable_count
+
                 if EPR_s:
                     summary["EPR_stable_pct_transects"] = (
                         f"{(stable_count / len(EPR)) * 100:.2f} %"
@@ -383,12 +389,13 @@ class ShorelineChange:
                     summary["EPR_stable_max"] = round(max(EPR_s), 2)
                     summary["EPR_stable_min"] = round(min(EPR_s), 2)
             else:
-                summary["EPR"] = None
+                summary["EPR"] = False
 
         if Statistic.LRR in self.shoreline_change_inputs["selected_stats"]:
             LRR = stat_values[Statistic.LRR]
 
             if LRR:
+                summary["LRR"] = True
                 summary["LRR_avg"] = round(sum(LRR) / len(LRR), 2)
 
                 LRR_e = [x for x in LRR if x < 0]
@@ -397,6 +404,7 @@ class ShorelineChange:
                 summary["LRR_erosion_pct_transects"] = (
                     f"{(erosion_count / len(LRR)) * 100:.2f} %"
                 )
+
                 if LRR_e:
                     summary["LRR_erosion_avg"] = round(sum(LRR_e) / len(LRR_e), 2)
                     summary["LRR_erosion_max"] = round(max(LRR_e), 2)
@@ -408,17 +416,19 @@ class ShorelineChange:
                 summary["LRR_accretion_pct_transects"] = (
                     f"{(accretion_count / len(LRR)) * 100:.2f} %"
                 )
+
                 if LRR_a:
                     summary["LRR_accretion_avg"] = round(sum(LRR_a) / len(LRR_a), 2)
                     summary["LRR_accretion_max"] = round(max(LRR_a), 2)
                     summary["LRR_accretion_min"] = round(min(LRR_a), 2)
             else:
-                summary["LRR"] = None
+                summary["LRR"] = False
 
         if Statistic.WLR in self.shoreline_change_inputs["selected_stats"]:
             WLR = stat_values[Statistic.WLR]
 
             if WLR:
+                summary["WLR"] = True
                 summary["WLR_avg"] = round(sum(WLR) / len(WLR), 2)
         
                 WLR_e = [x for x in WLR if x < 0]
@@ -427,6 +437,7 @@ class ShorelineChange:
                 summary["WLR_erosion_pct_transects"] = (
                     f"{(erosion_count / len(WLR)) * 100:.2f} %"
                 )
+
                 if WLR_e:
                     summary["WLR_erosion_avg"] = round(sum(WLR_e) / len(WLR_e), 2)
                     summary["WLR_erosion_max"] = round(max(WLR_e), 2)
@@ -438,12 +449,13 @@ class ShorelineChange:
                 summary["WLR_accretion_pct_transects"] = (
                     f"{(accretion_count / len(WLR)) * 100:.2f} %"
                 )
+                
                 if WLR_a:
                     summary["WLR_accretion_avg"] = round(sum(WLR_a) / len(WLR_a), 2)
                     summary["WLR_accretion_max"] = round(max(WLR_a), 2)
                     summary["WLR_accretion_min"] = round(min(WLR_a), 2)
             else:
-                summary["WLR"] = None
+                summary["WLR"] = False
 
         self.reports.summary = summary
         self.reports.shoreline_change()

--- a/qscat/core/tabs/shoreline_change.py
+++ b/qscat/core/tabs/shoreline_change.py
@@ -291,133 +291,159 @@ class ShorelineChange:
         # Results
         if Statistic.SCE in self.shoreline_change_inputs["selected_stats"]:
             SCE = stat_values[Statistic.SCE]
-            summary["SCE_avg"] = round(sum(SCE) / len(SCE), 2)
-            summary["SCE_max"] = round(max(SCE), 2)
-            summary["SCE_min"] = round(min(SCE), 2)
+
+            if SCE:
+                summary["SCE_avg"] = round(sum(SCE) / len(SCE), 2)
+                summary["SCE_max"] = round(max(SCE), 2)
+                summary["SCE_min"] = round(min(SCE), 2)
+            else:
+                summary["SCE"] = None
 
         if Statistic.NSM in self.shoreline_change_inputs["selected_stats"]:
             NSM = stat_values[Statistic.NSM]
-            unc = self.shoreline_change_inputs["highest_unc"]
-            summary["NSM_avg"] = round(sum(NSM) / len(NSM), 2)
 
-            NSM_e = [x for x in NSM if x < -unc]
-            erosion_count = len(NSM_e)
-            summary["NSM_erosion_num_of_transects"] = erosion_count
-            summary["NSM_erosion_pct_transects"] = (
-                f"{(erosion_count / len(NSM)) * 100:.2f} %"
-            )
-            if NSM_e:
-                summary["NSM_erosion_avg"] = round(sum(NSM_e) / len(NSM_e), 2)
-                summary["NSM_erosion_max"] = round(max(NSM_e), 2)
-                summary["NSM_erosion_min"] = round(min(NSM_e), 2)
+            if NSM:
+                unc = self.shoreline_change_inputs["highest_unc"]
+                summary["NSM_avg"] = round(sum(NSM) / len(NSM), 2)
 
-            NSM_a = [x for x in NSM if x > unc]
-            accretion_count = len(NSM_a)
-            summary["NSM_accretion_num_of_transects"] = accretion_count
-            summary["NSM_accretion_pct_transects"] = (
-                f"{(accretion_count / len(NSM)) * 100:.2f} %"
-            )
-            if NSM_a:
-                summary["NSM_accretion_avg"] = round(sum(NSM_a) / len(NSM_a), 2)
-                summary["NSM_accretion_max"] = round(max(NSM_a), 2)
-                summary["NSM_accretion_min"] = round(min(NSM_a), 2)
+                NSM_e = [x for x in NSM if x < -unc]
+                erosion_count = len(NSM_e)
+                summary["NSM_erosion_num_of_transects"] = erosion_count
+                
+                if NSM_e:
+                    summary["NSM_erosion_pct_transects"] = (
+                        f"{(erosion_count / len(NSM)) * 100:.2f} %"
+                    )
+                    summary["NSM_erosion_avg"] = round(sum(NSM_e) / len(NSM_e), 2)
+                    summary["NSM_erosion_max"] = round(max(NSM_e), 2)
+                    summary["NSM_erosion_min"] = round(min(NSM_e), 2)
 
-            NSM_s = [x for x in NSM if x >= -unc and x <= unc]
-            stable_count = len(NSM_s)
-            summary["NSM_stable_num_of_transects"] = stable_count
-            summary["NSM_stable_pct_transects"] = (
-                f"{(stable_count / len(NSM)) * 100:.2f} %"
-            )
-            if NSM_s:
-                summary["NSM_stable_avg"] = round(sum(NSM_s) / len(NSM_s), 2)
-                summary["NSM_stable_max"] = round(max(NSM_s), 2)
-                summary["NSM_stable_min"] = round(min(NSM_s), 2)
+                NSM_a = [x for x in NSM if x > unc]
+                accretion_count = len(NSM_a)
+                summary["NSM_accretion_num_of_transects"] = accretion_count
+                
+                if NSM_a:
+                    summary["NSM_accretion_pct_transects"] = (
+                        f"{(accretion_count / len(NSM)) * 100:.2f} %"
+                    )
+                    summary["NSM_accretion_avg"] = round(sum(NSM_a) / len(NSM_a), 2)
+                    summary["NSM_accretion_max"] = round(max(NSM_a), 2)
+                    summary["NSM_accretion_min"] = round(min(NSM_a), 2)
+
+                NSM_s = [x for x in NSM if x >= -unc and x <= unc]
+                stable_count = len(NSM_s)
+                summary["NSM_stable_num_of_transects"] = stable_count
+                if NSM_s:
+                    summary["NSM_stable_pct_transects"] = (
+                        f"{(stable_count / len(NSM)) * 100:.2f} %"
+                    )
+                    summary["NSM_stable_avg"] = round(sum(NSM_s) / len(NSM_s), 2)
+                    summary["NSM_stable_max"] = round(max(NSM_s), 2)
+                    summary["NSM_stable_min"] = round(min(NSM_s), 2)
+            else:
+                summary["NSM"] = None
 
         if Statistic.EPR in self.shoreline_change_inputs["selected_stats"]:
             EPR = stat_values[Statistic.EPR]
-            unc = self.shoreline_change_inputs["epr_unc"]
-            summary["EPR_avg"] = round(sum(EPR) / len(EPR), 2)
 
-            EPR_e = [x for x in EPR if x < -unc]
-            erosion_count = len(EPR_e)
-            summary["EPR_erosion_num_of_transects"] = erosion_count
-            summary["EPR_erosion_pct_transects"] = (
-                f"{(erosion_count / len(EPR)) * 100:.2f} %"
-            )
-            if EPR_e:
-                summary["EPR_erosion_avg"] = round(sum(EPR_e) / len(EPR_e), 2)
-                summary["EPR_erosion_max"] = round(max(EPR_e), 2)
-                summary["EPR_erosion_min"] = round(min(EPR_e), 2)
+            if EPR:
+                unc = self.shoreline_change_inputs["epr_unc"]
+                summary["EPR_avg"] = round(sum(EPR) / len(EPR), 2)
 
-            EPR_a = [x for x in EPR if x > unc]
-            accretion_count = len(EPR_a)
-            summary["EPR_accretion_num_of_transects"] = accretion_count
-            summary["EPR_accretion_pct_transects"] = (
-                f"{(accretion_count / len(EPR)) * 100:.2f} %"
-            )
-            if EPR_a:
-                summary["EPR_accretion_avg"] = round(sum(EPR_a) / len(EPR_a), 2)
-                summary["EPR_accretion_max"] = round(max(EPR_a), 2)
-                summary["EPR_accretion_min"] = round(min(EPR_a), 2)
+                EPR_e = [x for x in EPR if x < -unc]
+                erosion_count = len(EPR_e)
+                summary["EPR_erosion_num_of_transects"] = erosion_count
+                if EPR_e:
+                    summary["EPR_erosion_pct_transects"] = (
+                        f"{(erosion_count / len(EPR)) * 100:.2f} %"
+                    )
+                    summary["EPR_erosion_avg"] = round(sum(EPR_e) / len(EPR_e), 2)
+                    summary["EPR_erosion_max"] = round(max(EPR_e), 2)
+                    summary["EPR_erosion_min"] = round(min(EPR_e), 2)
 
-            EPR_s = [x for x in EPR if x >= -unc and x <= unc]
-            stable_count = len(EPR_s)
-            summary["EPR_stable_num_of_transects"] = stable_count
-            summary["EPR_stable_pct_transects"] = (
-                f"{(stable_count / len(EPR)) * 100:.2f} %"
-            )
-            if EPR_s:
-                summary["EPR_stable_avg"] = round(sum(EPR_s) / len(EPR_s), 2)
-                summary["EPR_stable_max"] = round(max(EPR_s), 2)
-                summary["EPR_stable_min"] = round(min(EPR_s), 2)
+                EPR_a = [x for x in EPR if x > unc]
+                accretion_count = len(EPR_a)
+                summary["EPR_accretion_num_of_transects"] = accretion_count
+                if EPR_a:
+                    summary["EPR_accretion_pct_transects"] = (
+                        f"{(accretion_count / len(EPR)) * 100:.2f} %"
+                    )
+                    summary["EPR_accretion_avg"] = round(sum(EPR_a) / len(EPR_a), 2)
+                    summary["EPR_accretion_max"] = round(max(EPR_a), 2)
+                    summary["EPR_accretion_min"] = round(min(EPR_a), 2)
+
+                EPR_s = [x for x in EPR if x >= -unc and x <= unc]
+                stable_count = len(EPR_s)
+                summary["EPR_stable_num_of_transects"] = stable_count
+                if EPR_s:
+                    summary["EPR_stable_pct_transects"] = (
+                        f"{(stable_count / len(EPR)) * 100:.2f} %"
+                    )
+                    summary["EPR_stable_avg"] = round(sum(EPR_s) / len(EPR_s), 2)
+                    summary["EPR_stable_max"] = round(max(EPR_s), 2)
+                    summary["EPR_stable_min"] = round(min(EPR_s), 2)
+            else:
+                summary["EPR"] = None
 
         if Statistic.LRR in self.shoreline_change_inputs["selected_stats"]:
             LRR = stat_values[Statistic.LRR]
-            summary["LRR_avg"] = round(sum(LRR) / len(LRR), 2)
 
-            LRR_e = [x for x in LRR if x < 0]
-            erosion_count = len(LRR_e)
-            summary["LRR_erosion_num_of_transects"] = erosion_count
-            summary["LRR_erosion_pct_transects"] = (
-                f"{(erosion_count / len(LRR)) * 100:.2f} %"
-            )
-            summary["LRR_erosion_avg"] = round(sum(LRR_e) / len(LRR_e), 2)
-            summary["LRR_erosion_max"] = round(max(LRR_e), 2)
-            summary["LRR_erosion_min"] = round(min(LRR_e), 2)
+            if LRR:
+                summary["LRR_avg"] = round(sum(LRR) / len(LRR), 2)
 
-            LRR_a = [x for x in LRR if x >= 0]
-            accretion_count = len(LRR_a)
-            summary["LRR_accretion_num_of_transects"] = accretion_count
-            summary["LRR_accretion_pct_transects"] = (
-                f"{(accretion_count / len(LRR)) * 100:.2f} %"
-            )
-            summary["LRR_accretion_avg"] = round(sum(LRR_a) / len(LRR_a), 2)
-            summary["LRR_accretion_max"] = round(max(LRR_a), 2)
-            summary["LRR_accretion_min"] = round(min(LRR_a), 2)
+                LRR_e = [x for x in LRR if x < 0]
+                erosion_count = len(LRR_e)
+                summary["LRR_erosion_num_of_transects"] = erosion_count
+                summary["LRR_erosion_pct_transects"] = (
+                    f"{(erosion_count / len(LRR)) * 100:.2f} %"
+                )
+                if LRR_e:
+                    summary["LRR_erosion_avg"] = round(sum(LRR_e) / len(LRR_e), 2)
+                    summary["LRR_erosion_max"] = round(max(LRR_e), 2)
+                    summary["LRR_erosion_min"] = round(min(LRR_e), 2)
+
+                LRR_a = [x for x in LRR if x >= 0]
+                accretion_count = len(LRR_a)
+                summary["LRR_accretion_num_of_transects"] = accretion_count
+                summary["LRR_accretion_pct_transects"] = (
+                    f"{(accretion_count / len(LRR)) * 100:.2f} %"
+                )
+                if LRR_a:
+                    summary["LRR_accretion_avg"] = round(sum(LRR_a) / len(LRR_a), 2)
+                    summary["LRR_accretion_max"] = round(max(LRR_a), 2)
+                    summary["LRR_accretion_min"] = round(min(LRR_a), 2)
+            else:
+                summary["LRR"] = None
 
         if Statistic.WLR in self.shoreline_change_inputs["selected_stats"]:
             WLR = stat_values[Statistic.WLR]
-            summary["WLR_avg"] = round(sum(WLR) / len(WLR), 2)
 
-            WLR_e = [x for x in WLR if x < 0]
-            erosion_count = len(WLR_e)
-            summary["WLR_erosion_num_of_transects"] = erosion_count
-            summary["WLR_erosion_pct_transects"] = (
-                f"{(erosion_count / len(WLR)) * 100:.2f} %"
-            )
-            summary["WLR_erosion_avg"] = round(sum(WLR_e) / len(WLR_e), 2)
-            summary["WLR_erosion_max"] = round(max(WLR_e), 2)
-            summary["WLR_erosion_min"] = round(min(WLR_e), 2)
+            if WLR:
+                summary["WLR_avg"] = round(sum(WLR) / len(WLR), 2)
+        
+                WLR_e = [x for x in WLR if x < 0]
+                erosion_count = len(WLR_e)
+                summary["WLR_erosion_num_of_transects"] = erosion_count
+                summary["WLR_erosion_pct_transects"] = (
+                    f"{(erosion_count / len(WLR)) * 100:.2f} %"
+                )
+                if WLR_e:
+                    summary["WLR_erosion_avg"] = round(sum(WLR_e) / len(WLR_e), 2)
+                    summary["WLR_erosion_max"] = round(max(WLR_e), 2)
+                    summary["WLR_erosion_min"] = round(min(WLR_e), 2)
 
-            WLR_a = [x for x in WLR if x >= 0]
-            accretion_count = len(WLR_a)
-            summary["WLR_accretion_num_of_transects"] = accretion_count
-            summary["WLR_accretion_pct_transects"] = (
-                f"{(accretion_count / len(WLR)) * 100:.2f} %"
-            )
-            summary["WLR_accretion_avg"] = round(sum(WLR_a) / len(WLR_a), 2)
-            summary["WLR_accretion_max"] = round(max(WLR_a), 2)
-            summary["WLR_accretion_min"] = round(min(WLR_a), 2)
+                WLR_a = [x for x in WLR if x >= 0]
+                accretion_count = len(WLR_a)
+                summary["WLR_accretion_num_of_transects"] = accretion_count
+                summary["WLR_accretion_pct_transects"] = (
+                    f"{(accretion_count / len(WLR)) * 100:.2f} %"
+                )
+                if WLR_a:
+                    summary["WLR_accretion_avg"] = round(sum(WLR_a) / len(WLR_a), 2)
+                    summary["WLR_accretion_max"] = round(max(WLR_a), 2)
+                    summary["WLR_accretion_min"] = round(min(WLR_a), 2)
+            else:
+                summary["WLR"] = None
 
         self.reports.summary = summary
         self.reports.shoreline_change()

--- a/qscat/metadata.txt
+++ b/qscat/metadata.txt
@@ -19,7 +19,7 @@ about=QSCAT offers the following features:
 
     For changelog please visit https://github.com/qscat/qscat/blob/master/CHANGELOG.md
 
-version=0.4.1
+version=0.4.2
 qgisMinimumVersion=3.22
 author=Louis Facun
 email=louisfacun@gmail.com


### PR DESCRIPTION
- Added error handling (ZeroDivisionError) in creating summary reports when there are no stable, eroding, or accreting class. And when a specific stat is checked but there no actual layer of that stat.
- Updated reports output to specify checked stat but missing, and missing classes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Development section to the README with environment setup and test instructions.
  * Added a dated 0.4.2 changelog entry, updated docs and release/version references, and removed social media links.

* **Bug Fixes**
  * Summary reports now omit empty statistics and show clear "no data" messages to avoid invalid aggregations and zero-division errors.

* **Chores**
  * Added a QGIS 3.36.1 development environment config and bumped project version/metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->